### PR TITLE
Return error if the entry is not found in the db.

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -122,8 +122,13 @@ func (r *Reader) Lookup(ipAddress net.IP, result interface{}) error {
 
 	pointer, err := r.findAddressInTree(ipAddress)
 
-	if pointer == 0 {
+	if err != nil {
 		return err
+	}
+
+	if pointer == 0 {
+		// No error occurred, but no data found in the db for the given IP address.
+		return fmt.Errorf("No record found for %s", ipAddress.String())
 	}
 
 	return r.retrieveData(pointer, result)


### PR DESCRIPTION
This will make the library users to easily identify when there is no data available for the given IP address.

Without passing this error, it makes it hard to identify if the passed record is filled by `Lookup` or not.