### PR TITLE
Add appengine build tags for windows

### DIFF
--- a/mmap_windows.go
+++ b/mmap_windows.go
@@ -1,3 +1,5 @@
+// +build windows,!appengine
+
 package maxminddb
 
 // Windows support largely borrowed from mmap-go.


### PR DESCRIPTION
When you run the local simulation of an appengine on windows,
the mmap_windows.go variant is selected, which requiring an import of unsafe.

Since unsafe is forbidden on appengine, we get an compile time error message looking like this:

The Go application could not be built. (Executed command: C:\go_appengine\goroot\bin\go-app-builder.exe -app_base C:\goroot\src<redacted>\appentry -arch 6 -dynamic -goroot C:\go_appengine\goroot -nobuild_files ^^$ -unsafe -gopath C:\goroot\ -print_extras_hash main.go) 2016/12/05 11:39:12 go-app-builder: Failed parsing input: parser: bad import "unsafe" in github.com\oschwald\maxminddb-golang\decoder.go from GOPATH

So we fix this by putting an explicit build tag which excludes appengine on windows there.