### PR TITLE
Reader: add nil checks to prevent panics

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -107,6 +107,9 @@ func (r *Reader) startNode() (uint, error) {
 // Lookup takes an IP address as a net.IP structure and a pointer to the
 // result value to Decode into.
 func (r *Reader) Lookup(ipAddress net.IP, result interface{}) error {
+	if r == nil {
+		return errors.New("not initialized")
+	}
 	pointer, err := r.lookupPointer(ipAddress)
 	if pointer == 0 || err != nil {
 		return err
@@ -120,6 +123,9 @@ func (r *Reader) Lookup(ipAddress net.IP, result interface{}) error {
 // is an advanced API, which exists to provide clients with a means to cache
 // previously-decoded records.
 func (r *Reader) LookupOffset(ipAddress net.IP) (uintptr, error) {
+	if r == nil {
+		return 0, errors.New("not initialized")
+	}
 	pointer, err := r.lookupPointer(ipAddress)
 	if pointer == 0 || err != nil {
 		return NotFound, err
@@ -144,6 +150,9 @@ func (r *Reader) LookupOffset(ipAddress net.IP) (uintptr, error) {
 // single representative record for that country. This uintptr behavior allows
 // clients to leverage this normalization in their own sub-record caching.
 func (r *Reader) Decode(offset uintptr, result interface{}) error {
+	if r == nil {
+		return errors.New("not initialized")
+	}
 	rv := reflect.ValueOf(result)
 	if rv.Kind() != reflect.Ptr || rv.IsNil() {
 		return errors.New("result param must be a pointer")

--- a/reader_test.go
+++ b/reader_test.go
@@ -29,6 +29,20 @@ func TestReader(t *testing.T) {
 			}
 		}
 	}
+
+	var reader *Reader
+	defer func() {
+		assert.Nil(t, recover(), "unexpected panic")
+	}()
+
+	decodeErr := reader.Decode(0, interface{}(nil))
+	assert.Error(t, decodeErr)
+
+	lookupErr := reader.Lookup(net.IPv4(127, 0, 0, 1), interface{}(nil))
+	assert.Error(t, lookupErr)
+
+	_, offsetErr := reader.LookupOffset(net.IPv4(127, 0, 0, 1))
+	assert.Error(t, offsetErr)
 }
 
 func TestReaderBytes(t *testing.T) {


### PR DESCRIPTION
This change adds nil checks to exported methods of `Reader`, in order to prevent panics.