### PR TITLE
Use https:// instead of git:// for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "test-data"]
 	path = test-data
-	url = git://github.com/maxmind/MaxMind-DB.git
+	url = https://github.com/maxmind/MaxMind-DB.git


### PR DESCRIPTION
It would be nice if we could use the most generic transport protocol here.
Our company's sysadmin won't allow git protocol traffic (9418/tcp) so I cannot go get this package.