### PR TITLE
Fix anonymous field index in range clause.

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -602,7 +602,7 @@ func (d *decoder) decodeStruct(
 	}
 
 	// This fills in embedded structs
-	for i := range fields.anonymousFields {
+	for _, i := range fields.anonymousFields {
 		_, err := d.unmarshalMap(size, offset, result.Field(i), depth)
 		if err != nil {
 			return 0, err


### PR DESCRIPTION
Given the anonymousFields value []int{4, 5}, struct fields 0 and 1 were being decoded into instead of 4 and 5.