### PR TITLE
Added methods capable of returning the netmask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.out
 *.sw?
 *.test
+# JetBrains GoLand
+.idea/

--- a/reader.go
+++ b/reader.go
@@ -236,6 +236,9 @@ func (r *Reader) Netmask(ipAddress net.IP) (uint, error) {
 		// Record is empty
 		return 0, nil
 	} else if node > nodeCount {
+		if r.Metadata.IPVersion == 6 && ipAddress.To4() != nil {
+			return i - 96, nil
+		}
 		return i, nil
 	}
 


### PR DESCRIPTION
Two methods were added to find the netmask of an IP address, both are based in the findAddressInTree() method found on the Reader struct.

- Netmask() returns the netmask value along with any errors found. Heavily based on findAddressInTree().
- LookupOffsetWithNetmask() adds an additional return value with the netmask value.

Both methods are suited for NS1's needs but we think they may be useful.