### PR TITLE
add gomodules support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ go:
  - 1.11
  - tip
 
+env:
+  - GO111MODULE=on
+
 before_install:
   - "if [[ $TRAVIS_GO_VERSION == 1.11 ]]; then go get -u golang.org/x/lint/golint; fi"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ clone_folder: c:\gopath\src\github.com\oschwald\maxminddb-golang
 
 environment:
   GOPATH: c:\gopath
+  GO111MODULE: on
 
 install:
   - echo %PATH%

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/oschwald/maxminddb-golang
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.2.2
+	golang.org/x/sys v0.0.0-20181218192612-074acd46bca6
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20181218192612-074acd46bca6 h1:MXtOG7w2ND9qNCUZSDBGll/SpVIq7ftozR9I8/JGBHY=
+golang.org/x/sys v0.0.0-20181218192612-074acd46bca6/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
[Go Modules][modules] 📦 have been supported since Go 1.11 as the officially blessed "preliminary support" for dependency management and reproducible builds, and while the writing was on the wall for a while, it seems it's [now official][announcement] that this seems to be the path forward in the Go ecosystem.

This PR adds a standard go module definition for this repository (generated via `go mod init` and `go mod tidy`), indicating the current state of the dependency chain. This should simplify things for other people importing this library in their projects (like me!), as well as some other niceness like allowing working outside of GOPATH if desired.

(Note: I'm not 100% certain, but I believe due to semantic versioning requirements any other programs which depend on this will not be able to actually take advantage until there is a tagged git release that includes it, even after it is merged.)

[modules]: https://github.com/golang/go/wiki/Modules
[announcement]: https://blog.golang.org/modules2019