### PR TITLE
trivial: SVG badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # MaxMind DB Reader for Go #
 
-[![Build Status](https://travis-ci.org/oschwald/maxminddb-golang.png?branch=master)](https://travis-ci.org/oschwald/maxminddb-golang)
+[![Build Status](https://travis-ci.org/oschwald/maxminddb-golang.svg?branch=master)](https://travis-ci.org/oschwald/maxminddb-golang)
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/4j2f9oep8nnfrmov/branch/master?svg=true)](https://ci.appveyor.com/project/oschwald/maxminddb-golang/branch/master)
-[![GoDoc](https://godoc.org/github.com/oschwald/maxminddb-golang?status.png)](https://godoc.org/github.com/oschwald/maxminddb-golang)
+[![GoDoc](https://godoc.org/github.com/oschwald/maxminddb-golang?status.svg)](https://godoc.org/github.com/oschwald/maxminddb-golang)
 
 This is a Go reader for the MaxMind DB format. Although this can be used to
 read [GeoLite2](http://dev.maxmind.com/geoip/geoip2/geolite2/) and


### PR DESCRIPTION
Two of the three badges at the top of the README were using the PNG image version instead of the SVG version. This made them look a little strange and blurry in comparison when viewing on a Retina/HiDPI screen.

This switches to the SVG versions, which look cleaner and are likely slightly smaller file size anyhow.

Completely trivial, but it looks nicer. 😄 