### PR TITLE
Return err when lookup fails.

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -111,8 +111,11 @@ func (r *Reader) Lookup(ipAddress net.IP, result interface{}) error {
 		return errors.New("cannot call Lookup on a closed database")
 	}
 	pointer, err := r.lookupPointer(ipAddress)
-	if pointer == 0 || err != nil {
+	if err != nil {
 		return err
+	}
+	if pointer == 0 {
+		return errors.New("not found")
 	}
 	return r.retrieveData(pointer, result)
 }


### PR DESCRIPTION
One would hope to be able to distinguish between an IP address with no registered country (or city) without examining each and every member of the returned struct, but that does not appear to be possible, because `maxminddb.Reader.Lookup` obscures the difference.

This change breaks many tests that currently expect nil, even though a record was not found.

If it is desired that errors be reserved for operational issues, this information needs to be made available to `geoip2` from `maxminddb` so that `geoip2` can return a nil for `*City` or `*Country` instead of an error.

It would be possible to work around this issue without breaking the existing API by using `LookupOffset` and `Decode` in `maxminddb`, but the `maxminddb.Reader` instance is private in `geoip2`, so 3rd-party code can't reach it.

Alternatively, in order to maintain strict backwards-compatibility, I could implement new methods in `geoip2.Reader` that would lookup records and behave as desired, but that would mean adding 7 new methods or a new mode for the 7 existing methods.
