### PR TITLE
Add plan9 support

### DIFF
--- a/mmap_unix.go
+++ b/mmap_unix.go
@@ -1,4 +1,4 @@
-// +build !windows,!appengine
+// +build !windows,!appengine,!plan9
 
 package maxminddb
 

--- a/reader_appengine.go
+++ b/reader_appengine.go
@@ -1,4 +1,4 @@
-// +build appengine
+// +build appengine plan9
 
 package maxminddb
 

--- a/reader_other.go
+++ b/reader_other.go
@@ -1,4 +1,4 @@
-// +build !appengine
+// +build !appengine,!plan9
 
 package maxminddb
 


### PR DESCRIPTION
Since plan9 does not have mmap, this allows it to be built in the same way the library is built for google app engine.