### PR TITLE
Add wasi directives for tinygo

### DIFF
--- a/mmap_unix.go
+++ b/mmap_unix.go
@@ -1,5 +1,5 @@
-//go:build !windows && !appengine && !plan9 && !js && !wasip1
-// +build !windows,!appengine,!plan9,!js,!wasip1
+//go:build !windows && !appengine && !plan9 && !js && !wasip1 && !wasi
+// +build !windows,!appengine,!plan9,!js,!wasip1,!wasi
 
 package maxminddb
 

--- a/reader_memory.go
+++ b/reader_memory.go
@@ -1,5 +1,5 @@
-//go:build appengine || plan9 || js || wasip1
-// +build appengine plan9 js wasip1
+//go:build appengine || plan9 || js || wasip1 || wasi
+// +build appengine plan9 js wasip1 wasi
 
 package maxminddb
 

--- a/reader_mmap.go
+++ b/reader_mmap.go
@@ -1,5 +1,5 @@
-//go:build !appengine && !plan9 && !js && !wasip1
-// +build !appengine,!plan9,!js,!wasip1
+//go:build !appengine && !plan9 && !js && !wasip1 && !wasi
+// +build !appengine,!plan9,!js,!wasip1,!wasi
 
 package maxminddb
 


### PR DESCRIPTION
**Goal**
Adding WASI directives to be able to compile with tinygo (and use it with WASM for Envoy). 

Without these directives for compiler, compiling with tinygo v0.28.1 on Darwin fails with:
```
tinygo build -o main.wasm -scheduler=none -target=wasi main.go
# golang.org/x/sys/unix
../../go/pkg/mod/golang.org/x/sys@v0.10.0/unix/syscall_linux.go:1901:64: undefined: syscall.Rlimit
../../go/pkg/mod/golang.org/x/sys@v0.10.0/unix/syscall_linux.go:1906:50: undefined: syscall.Rlimit
../../go/pkg/mod/golang.org/x/sys@v0.10.0/unix/syscall_linux.go:1906:79: undefined: syscall.Rlimit
../../go/pkg/mod/golang.org/x/sys@v0.10.0/unix/syscall_unix.go:595:17: undefined: syscall.Setrlimit
../../go/pkg/mod/golang.org/x/sys@v0.10.0/unix/syscall_unix.go:595:47: undefined: syscall.Rlimit
```