### PR TITLE
Build tag 'maxminddisablemmap' to disable mmap() even when supported

### DIFF
--- a/reader_memory.go
+++ b/reader_memory.go
@@ -1,5 +1,5 @@
-//go:build appengine || plan9 || js || wasip1 || wasi
-// +build appengine plan9 js wasip1 wasi
+//go:build appengine || plan9 || js || wasip1 || wasi || maxminddisablemmap
+// +build appengine plan9 js wasip1 wasi maxminddisablemmap
 
 package maxminddb
 
@@ -9,6 +9,7 @@ import "io/ioutil"
 // structure or an error. The database file is opened using a memory map
 // on supported platforms. On platforms without memory map support, such
 // as WebAssembly or Google App Engine, the database is loaded into memory.
+// use '-tags maxminddisablemmap' for force DB to be loaded in memory
 // Use the Close method on the Reader object to return the resources to the system.
 func Open(file string) (*Reader, error) {
 	bytes, err := ioutil.ReadFile(file)

--- a/reader_mmap.go
+++ b/reader_mmap.go
@@ -1,5 +1,5 @@
-//go:build !appengine && !plan9 && !js && !wasip1 && !wasi
-// +build !appengine,!plan9,!js,!wasip1,!wasi
+//go:build !appengine && !plan9 && !js && !wasip1 && !wasi && !maxminddisablemmap
+// +build !appengine,!plan9,!js,!wasip1,!wasi,!maxminddisablemmap
 
 package maxminddb
 
@@ -12,6 +12,7 @@ import (
 // structure or an error. The database file is opened using a memory map
 // on supported platforms. On platforms without memory map support, such
 // as WebAssembly or Google App Engine, the database is loaded into memory.
+// use '-tags maxminddisablemmap' for force DB to be loaded in memory
 // Use the Close method on the Reader object to return the resources to the system.
 func Open(file string) (*Reader, error) {
 	mapFile, err := os.Open(file)


### PR DESCRIPTION
Adding a build tag 'maxminddisablemmap' to force in-memory loaded database, even when mmap() is supported.

Maxmind database file content (ex: GeoIP2-Country.mmdb) being modified/updated 'on the fly' while it is opened by Reader with mmap() can lead to unexpected and catastrophic behaviour.

This patch modifies slightly "reader_memory.go" & "reader_mmap.go" to provide a way to disable mmap() usage in maxminddb-golang, using '-tags maxminddisablemmap' (ex: go run -tags maxminddisablemmap) 