### PR TITLE
Return first IP in network with NetworksWithin

### DIFF
--- a/traverse.go
+++ b/traverse.go
@@ -95,6 +95,10 @@ func (r *Reader) NetworksWithin(network *net.IPNet, options ...NetworksOption) *
 	}
 
 	pointer, bit := r.traverseTree(ip, 0, uint(prefixLength))
+
+	if bit < prefixLength {
+		ip = ip.Mask(net.CIDRMask(bit, len(ip)*8))
+	}
 	networks.nodes = []netNode{
 		{
 			ip:      ip,

--- a/traverse.go
+++ b/traverse.go
@@ -96,9 +96,12 @@ func (r *Reader) NetworksWithin(network *net.IPNet, options ...NetworksOption) *
 
 	pointer, bit := r.traverseTree(ip, 0, uint(prefixLength))
 
-	if bit < prefixLength {
-		ip = ip.Mask(net.CIDRMask(bit, len(ip)*8))
-	}
+	// We could skip this when bit >= prefixLength if we assume that the network
+	// passed in is in canonical form. However, given that this may not be the
+	// case, it is safest to always take the mask. If this is hot code at some
+	// point, we could eliminate the allocation of the net.IPMask by zeroing
+	// out the bits in ip directly.
+	ip = ip.Mask(net.CIDRMask(bit, len(ip)*8))
 	networks.nodes = []netNode{
 		{
 			ip:      ip,

--- a/traverse_test.go
+++ b/traverse_test.go
@@ -86,6 +86,27 @@ var tests = []networkTest{
 		},
 	},
 	{
+		Network:  "1.1.1.2/32",
+		Database: "ipv4",
+		Expected: []string{
+			"1.1.1.2/31",
+		},
+	},
+	{
+		Network:  "1.1.1.3/32",
+		Database: "ipv4",
+		Expected: []string{
+			"1.1.1.2/31",
+		},
+	},
+	{
+		Network:  "1.1.1.19/32",
+		Database: "ipv4",
+		Expected: []string{
+			"1.1.1.16/28",
+		},
+	},
+	{
 		Network:  "255.255.255.0/24",
 		Database: "ipv4",
 		Expected: []string(nil),


### PR DESCRIPTION
Previously, if the network being looked up was more specific than the network
in the database, the network number would be set to the network number of the
network being looked up rather than it being placed in canonical form.
