### PR TITLE
Add intermediate Result type during lookup

### DIFF
--- a/.golangci.toml
+++ b/.golangci.toml
@@ -18,6 +18,7 @@ disable = [
     "forcetypeassert",
     "funlen",
     "gochecknoglobals",
+    "gocognit",
     "godox",
     "gomnd",
     "inamedparam",

--- a/decoder.go
+++ b/decoder.go
@@ -89,6 +89,82 @@ func (d *decoder) decodeToDeserializer(
 	return d.decodeFromTypeToDeserializer(typeNum, size, newOffset, dser, depth+1)
 }
 
+func (d *decoder) decodePath(
+	offset uint,
+	path []any,
+	result reflect.Value,
+) error {
+PATH:
+	for i, v := range path {
+		var (
+			typeNum dataType
+			size    uint
+			err     error
+		)
+		typeNum, size, offset, err = d.decodeCtrlData(offset)
+		if err != nil {
+			return err
+		}
+
+		if typeNum == _Pointer {
+			pointer, _, err := d.decodePointer(size, offset)
+			if err != nil {
+				return err
+			}
+
+			typeNum, size, offset, err = d.decodeCtrlData(pointer)
+			if err != nil {
+				return err
+			}
+		}
+
+		switch v := v.(type) {
+		case string:
+			// We are expecting a map
+			if typeNum != _Map {
+				// XXX - use type names in errors.
+				return fmt.Errorf("expected a map for %s but found %d", v, typeNum)
+			}
+			for i := uint(0); i < size; i++ {
+				var key []byte
+				key, offset, err = d.decodeKey(offset)
+				if err != nil {
+					return err
+				}
+				if string(key) == v {
+					continue PATH
+				}
+				offset, err = d.nextValueOffset(offset, 1)
+				if err != nil {
+					return err
+				}
+			}
+			// Not found. Maybe return a boolean?
+			return nil
+		case int:
+			// We are expecting an array
+			if typeNum != _Slice {
+				// XXX - use type names in errors.
+				return fmt.Errorf("expected a slice for %d but found %d", v, typeNum)
+			}
+			if size < uint(v) {
+				// Slice is smaller than index, not found
+				return nil
+			}
+			// TODO: support negative indexes? Seems useful for subdivisions in
+			// particular.
+			offset, err = d.nextValueOffset(offset, uint(v))
+			if err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unexpected type for %d value in path, %v: %T", i, v, v)
+		}
+	}
+	_, err := d.decode(offset, result, len(path))
+	return err
+}
+
 func (d *decoder) decodeCtrlData(offset uint) (dataType, uint, uint, error) {
 	newOffset := offset + 1
 	if offset >= uint(len(d.buffer)) {

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -207,7 +207,7 @@ func validateDecoding(t *testing.T, tests map[string]any) {
 	for inputStr, expected := range tests {
 		inputBytes, err := hex.DecodeString(inputStr)
 		require.NoError(t, err)
-		d := decoder{inputBytes}
+		d := decoder{buffer: inputBytes}
 
 		var result any
 		_, err = d.decode(0, reflect.ValueOf(&result), 0)
@@ -223,7 +223,7 @@ func validateDecoding(t *testing.T, tests map[string]any) {
 func TestPointers(t *testing.T) {
 	bytes, err := os.ReadFile(testFile("maps-with-pointers.raw"))
 	require.NoError(t, err)
-	d := decoder{bytes}
+	d := decoder{buffer: bytes}
 
 	expected := map[uint]map[string]string{
 		0:  {"long_key": "long_value1"},

--- a/deserializer_test.go
+++ b/deserializer_test.go
@@ -13,7 +13,7 @@ func TestDecodingToDeserializer(t *testing.T) {
 	require.NoError(t, err, "unexpected error while opening database: %v", err)
 
 	dser := testDeserializer{}
-	err = reader.Lookup(netip.MustParseAddr("::1.1.1.0"), &dser)
+	err = reader.Lookup(netip.MustParseAddr("::1.1.1.0")).Decode(&dser)
 	require.NoError(t, err, "unexpected error while doing lookup: %v", err)
 
 	checkDecodingToInterface(t, dser.rv)

--- a/example_test.go
+++ b/example_test.go
@@ -24,7 +24,7 @@ func ExampleReader_Lookup_struct() {
 		} `maxminddb:"country"`
 	} // Or any appropriate struct
 
-	err = db.Lookup(addr, &record)
+	err = db.Lookup(addr).Decode(&record)
 	if err != nil {
 		log.Panic(err)
 	}
@@ -44,7 +44,7 @@ func ExampleReader_Lookup_interface() {
 	addr := netip.MustParseAddr("81.2.69.142")
 
 	var record any
-	err = db.Lookup(addr, &record)
+	err = db.Lookup(addr).Decode(&record)
 	if err != nil {
 		log.Panic(err)
 	}

--- a/reader_test.go
+++ b/reader_test.go
@@ -100,95 +100,95 @@ func TestLookupNetwork(t *testing.T) {
 	}
 
 	tests := []struct {
-		IP             netip.Addr
-		DBFile         string
-		ExpectedCIDR   string
-		ExpectedRecord any
-		ExpectedOK     bool
+		IP              netip.Addr
+		DBFile          string
+		ExpectedNetwork string
+		ExpectedRecord  any
+		ExpectedFound   bool
 	}{
 		{
-			IP:             netip.MustParseAddr("1.1.1.1"),
-			DBFile:         "MaxMind-DB-test-ipv6-32.mmdb",
-			ExpectedCIDR:   "1.0.0.0/8",
-			ExpectedRecord: nil,
-			ExpectedOK:     false,
+			IP:              netip.MustParseAddr("1.1.1.1"),
+			DBFile:          "MaxMind-DB-test-ipv6-32.mmdb",
+			ExpectedNetwork: "1.0.0.0/8",
+			ExpectedRecord:  nil,
+			ExpectedFound:   false,
 		},
 		{
-			IP:             netip.MustParseAddr("::1:ffff:ffff"),
-			DBFile:         "MaxMind-DB-test-ipv6-24.mmdb",
-			ExpectedCIDR:   "::1:ffff:ffff/128",
-			ExpectedRecord: map[string]any{"ip": "::1:ffff:ffff"},
-			ExpectedOK:     true,
+			IP:              netip.MustParseAddr("::1:ffff:ffff"),
+			DBFile:          "MaxMind-DB-test-ipv6-24.mmdb",
+			ExpectedNetwork: "::1:ffff:ffff/128",
+			ExpectedRecord:  map[string]any{"ip": "::1:ffff:ffff"},
+			ExpectedFound:   true,
 		},
 		{
-			IP:             netip.MustParseAddr("::2:0:1"),
-			DBFile:         "MaxMind-DB-test-ipv6-24.mmdb",
-			ExpectedCIDR:   "::2:0:0/122",
-			ExpectedRecord: map[string]any{"ip": "::2:0:0"},
-			ExpectedOK:     true,
+			IP:              netip.MustParseAddr("::2:0:1"),
+			DBFile:          "MaxMind-DB-test-ipv6-24.mmdb",
+			ExpectedNetwork: "::2:0:0/122",
+			ExpectedRecord:  map[string]any{"ip": "::2:0:0"},
+			ExpectedFound:   true,
 		},
 		{
-			IP:             netip.MustParseAddr("1.1.1.1"),
-			DBFile:         "MaxMind-DB-test-ipv4-24.mmdb",
-			ExpectedCIDR:   "1.1.1.1/32",
-			ExpectedRecord: map[string]any{"ip": "1.1.1.1"},
-			ExpectedOK:     true,
+			IP:              netip.MustParseAddr("1.1.1.1"),
+			DBFile:          "MaxMind-DB-test-ipv4-24.mmdb",
+			ExpectedNetwork: "1.1.1.1/32",
+			ExpectedRecord:  map[string]any{"ip": "1.1.1.1"},
+			ExpectedFound:   true,
 		},
 		{
-			IP:             netip.MustParseAddr("1.1.1.3"),
-			DBFile:         "MaxMind-DB-test-ipv4-24.mmdb",
-			ExpectedCIDR:   "1.1.1.2/31",
-			ExpectedRecord: map[string]any{"ip": "1.1.1.2"},
-			ExpectedOK:     true,
+			IP:              netip.MustParseAddr("1.1.1.3"),
+			DBFile:          "MaxMind-DB-test-ipv4-24.mmdb",
+			ExpectedNetwork: "1.1.1.2/31",
+			ExpectedRecord:  map[string]any{"ip": "1.1.1.2"},
+			ExpectedFound:   true,
 		},
 		{
-			IP:             netip.MustParseAddr("1.1.1.3"),
-			DBFile:         "MaxMind-DB-test-decoder.mmdb",
-			ExpectedCIDR:   "1.1.1.0/24",
-			ExpectedRecord: decoderRecord,
-			ExpectedOK:     true,
+			IP:              netip.MustParseAddr("1.1.1.3"),
+			DBFile:          "MaxMind-DB-test-decoder.mmdb",
+			ExpectedNetwork: "1.1.1.0/24",
+			ExpectedRecord:  decoderRecord,
+			ExpectedFound:   true,
 		},
 		{
-			IP:             netip.MustParseAddr("::ffff:1.1.1.128"),
-			DBFile:         "MaxMind-DB-test-decoder.mmdb",
-			ExpectedCIDR:   "::ffff:1.1.1.0/120",
-			ExpectedRecord: decoderRecord,
-			ExpectedOK:     true,
+			IP:              netip.MustParseAddr("::ffff:1.1.1.128"),
+			DBFile:          "MaxMind-DB-test-decoder.mmdb",
+			ExpectedNetwork: "::ffff:1.1.1.0/120",
+			ExpectedRecord:  decoderRecord,
+			ExpectedFound:   true,
 		},
 		{
-			IP:             netip.MustParseAddr("::1.1.1.128"),
-			DBFile:         "MaxMind-DB-test-decoder.mmdb",
-			ExpectedCIDR:   "::101:100/120",
-			ExpectedRecord: decoderRecord,
-			ExpectedOK:     true,
+			IP:              netip.MustParseAddr("::1.1.1.128"),
+			DBFile:          "MaxMind-DB-test-decoder.mmdb",
+			ExpectedNetwork: "::101:100/120",
+			ExpectedRecord:  decoderRecord,
+			ExpectedFound:   true,
 		},
 		{
-			IP:             netip.MustParseAddr("200.0.2.1"),
-			DBFile:         "MaxMind-DB-no-ipv4-search-tree.mmdb",
-			ExpectedCIDR:   "::/64",
-			ExpectedRecord: "::0/64",
-			ExpectedOK:     true,
+			IP:              netip.MustParseAddr("200.0.2.1"),
+			DBFile:          "MaxMind-DB-no-ipv4-search-tree.mmdb",
+			ExpectedNetwork: "::/64",
+			ExpectedRecord:  "::0/64",
+			ExpectedFound:   true,
 		},
 		{
-			IP:             netip.MustParseAddr("::200.0.2.1"),
-			DBFile:         "MaxMind-DB-no-ipv4-search-tree.mmdb",
-			ExpectedCIDR:   "::/64",
-			ExpectedRecord: "::0/64",
-			ExpectedOK:     true,
+			IP:              netip.MustParseAddr("::200.0.2.1"),
+			DBFile:          "MaxMind-DB-no-ipv4-search-tree.mmdb",
+			ExpectedNetwork: "::/64",
+			ExpectedRecord:  "::0/64",
+			ExpectedFound:   true,
 		},
 		{
-			IP:             netip.MustParseAddr("0:0:0:0:ffff:ffff:ffff:ffff"),
-			DBFile:         "MaxMind-DB-no-ipv4-search-tree.mmdb",
-			ExpectedCIDR:   "::/64",
-			ExpectedRecord: "::0/64",
-			ExpectedOK:     true,
+			IP:              netip.MustParseAddr("0:0:0:0:ffff:ffff:ffff:ffff"),
+			DBFile:          "MaxMind-DB-no-ipv4-search-tree.mmdb",
+			ExpectedNetwork: "::/64",
+			ExpectedRecord:  "::0/64",
+			ExpectedFound:   true,
 		},
 		{
-			IP:             netip.MustParseAddr("ef00::"),
-			DBFile:         "MaxMind-DB-no-ipv4-search-tree.mmdb",
-			ExpectedCIDR:   "8000::/1",
-			ExpectedRecord: nil,
-			ExpectedOK:     false,
+			IP:              netip.MustParseAddr("ef00::"),
+			DBFile:          "MaxMind-DB-no-ipv4-search-tree.mmdb",
+			ExpectedNetwork: "8000::/1",
+			ExpectedRecord:  nil,
+			ExpectedFound:   false,
 		},
 	}
 
@@ -198,10 +198,12 @@ func TestLookupNetwork(t *testing.T) {
 			reader, err := Open(testFile(test.DBFile))
 			require.NoError(t, err)
 
-			network, ok, err := reader.LookupNetwork(test.IP, &record)
-			require.NoError(t, err)
-			assert.Equal(t, test.ExpectedOK, ok)
-			assert.Equal(t, test.ExpectedCIDR, network.String())
+			result := reader.Lookup(test.IP)
+			require.NoError(t, result.Err())
+			assert.Equal(t, test.ExpectedFound, result.Found())
+			assert.Equal(t, test.ExpectedNetwork, result.Network().String())
+
+			require.NoError(t, result.Decode(&record))
 			assert.Equal(t, test.ExpectedRecord, record)
 		})
 	}
@@ -819,20 +821,22 @@ func BenchmarkInterfaceLookup(b *testing.B) {
 	require.NoError(b, db.Close(), "error on close")
 }
 
-func BenchmarkInterfaceLookupNetwork(b *testing.B) {
+func BenchmarkLookupNetwork(b *testing.B) {
 	db, err := Open("GeoLite2-City.mmdb")
 	require.NoError(b, err)
 
 	//nolint:gosec // this is a test
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	var result any
 
 	s := make(net.IP, 4)
 	for i := 0; i < b.N; i++ {
 		ip := randomIPv4Address(r, s)
-		_, _, err = db.LookupNetwork(ip, &result)
-		if err != nil {
+		res := db.Lookup(ip)
+		if err := res.Err(); err != nil {
 			b.Error(err)
+		}
+		if !res.Network().IsValid() {
+			b.Fatalf("invalid network for %s", ip)
 		}
 	}
 	require.NoError(b, db.Close(), "error on close")
@@ -907,19 +911,18 @@ func BenchmarkCityLookup(b *testing.B) {
 	require.NoError(b, db.Close(), "error on close")
 }
 
-func BenchmarkCityLookupNetwork(b *testing.B) {
+func BenchmarkCityLookupOnly(b *testing.B) {
 	db, err := Open("GeoLite2-City.mmdb")
 	require.NoError(b, err)
 
 	//nolint:gosec // this is a test
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	var result fullCity
 
 	s := make(net.IP, 4)
 	for i := 0; i < b.N; i++ {
 		ip := randomIPv4Address(r, s)
-		_, _, err = db.LookupNetwork(ip, &result)
-		if err != nil {
+		result := db.Lookup(ip)
+		if err := result.Err(); err != nil {
 			b.Error(err)
 		}
 	}

--- a/reader_test.go
+++ b/reader_test.go
@@ -212,7 +212,7 @@ func TestDecodingToInterface(t *testing.T) {
 	require.NoError(t, err, "unexpected error while opening database: %v", err)
 
 	var recordInterface any
-	err = reader.Lookup(netip.MustParseAddr("::1.1.1.0"), &recordInterface)
+	err = reader.Lookup(netip.MustParseAddr("::1.1.1.0")).Decode(&recordInterface)
 	require.NoError(t, err, "unexpected error while doing lookup: %v", err)
 
 	checkDecodingToInterface(t, recordInterface)
@@ -299,7 +299,7 @@ func TestDecoder(t *testing.T) {
 	{
 		// Directly lookup and decode.
 		var result TestType
-		require.NoError(t, reader.Lookup(netip.MustParseAddr("::1.1.1.0"), &result))
+		require.NoError(t, reader.Lookup(netip.MustParseAddr("::1.1.1.0")).Decode(&result))
 		verify(result)
 	}
 	{
@@ -330,7 +330,7 @@ func TestStructInterface(t *testing.T) {
 	reader, err := Open(testFile("MaxMind-DB-test-decoder.mmdb"))
 	require.NoError(t, err)
 
-	require.NoError(t, reader.Lookup(netip.MustParseAddr("::1.1.1.0"), &result))
+	require.NoError(t, reader.Lookup(netip.MustParseAddr("::1.1.1.0")).Decode(&result))
 
 	assert.True(t, result.method())
 }
@@ -341,7 +341,7 @@ func TestNonEmptyNilInterface(t *testing.T) {
 	reader, err := Open(testFile("MaxMind-DB-test-decoder.mmdb"))
 	require.NoError(t, err)
 
-	err = reader.Lookup(netip.MustParseAddr("::1.1.1.0"), &result)
+	err = reader.Lookup(netip.MustParseAddr("::1.1.1.0")).Decode(&result)
 	assert.Equal(
 		t,
 		"maxminddb: cannot unmarshal map into type maxminddb.TestInterface",
@@ -364,7 +364,7 @@ func TestEmbeddedStructAsInterface(t *testing.T) {
 	db, err := Open(testFile("GeoIP2-ISP-Test.mmdb"))
 	require.NoError(t, err)
 
-	require.NoError(t, db.Lookup(netip.MustParseAddr("1.128.0.0"), &result))
+	require.NoError(t, db.Lookup(netip.MustParseAddr("1.128.0.0")).Decode(&result))
 }
 
 type BoolInterface interface {
@@ -390,7 +390,7 @@ func TestValueTypeInterface(t *testing.T) {
 
 	// although it would be nice to support cases like this, I am not sure it
 	// is possible to do so in a general way.
-	assert.Error(t, reader.Lookup(netip.MustParseAddr("::1.1.1.0"), &result))
+	assert.Error(t, reader.Lookup(netip.MustParseAddr("::1.1.1.0")).Decode(&result))
 }
 
 type NestedMapX struct {
@@ -432,7 +432,7 @@ func TestComplexStructWithNestingAndPointer(t *testing.T) {
 
 	var result TestPointerType
 
-	err = reader.Lookup(netip.MustParseAddr("::1.1.1.0"), &result)
+	err = reader.Lookup(netip.MustParseAddr("::1.1.1.0")).Decode(&result)
 	require.NoError(t, err)
 
 	assert.Equal(t, []uint{uint(1), uint(2), uint(3)}, *result.Array)
@@ -464,7 +464,7 @@ func TestNestedMapDecode(t *testing.T) {
 
 	var r map[string]map[string]any
 
-	require.NoError(t, db.Lookup(netip.MustParseAddr("89.160.20.128"), &r))
+	require.NoError(t, db.Lookup(netip.MustParseAddr("89.160.20.128")).Decode(&r))
 
 	assert.Equal(
 		t,
@@ -564,7 +564,7 @@ func TestDecodingUint16IntoInt(t *testing.T) {
 	var result struct {
 		Uint16 int `maxminddb:"uint16"`
 	}
-	err = reader.Lookup(netip.MustParseAddr("::1.1.1.0"), &result)
+	err = reader.Lookup(netip.MustParseAddr("::1.1.1.0")).Decode(&result)
 	require.NoError(t, err)
 
 	assert.Equal(t, 100, result.Uint16)
@@ -575,7 +575,7 @@ func TestIpv6inIpv4(t *testing.T) {
 	require.NoError(t, err, "unexpected error while opening database: %v", err)
 
 	var result TestType
-	err = reader.Lookup(netip.MustParseAddr("2001::"), &result)
+	err = reader.Lookup(netip.MustParseAddr("2001::")).Decode(&result)
 
 	var emptyResult TestType
 	assert.Equal(t, emptyResult, result)
@@ -592,7 +592,7 @@ func TestBrokenDoubleDatabase(t *testing.T) {
 	require.NoError(t, err, "unexpected error while opening database: %v", err)
 
 	var result any
-	err = reader.Lookup(netip.MustParseAddr("2001:220::"), &result)
+	err = reader.Lookup(netip.MustParseAddr("2001:220::")).Decode(&result)
 
 	expected := newInvalidDatabaseError(
 		"the MaxMind DB file's data section contains bad data (float 64 size of 2)",
@@ -625,7 +625,7 @@ func TestDecodingToNonPointer(t *testing.T) {
 	require.NoError(t, err)
 
 	var recordInterface any
-	err = reader.Lookup(netip.MustParseAddr("::1.1.1.0"), recordInterface)
+	err = reader.Lookup(netip.MustParseAddr("::1.1.1.0")).Decode(recordInterface)
 	assert.Equal(t, "result param must be a pointer", err.Error())
 	require.NoError(t, reader.Close(), "error on close")
 }
@@ -635,7 +635,7 @@ func TestDecodingToNonPointer(t *testing.T) {
 // 	require.NoError(t, err)
 
 // 	var recordInterface any
-// 	err = reader.Lookup(nil, recordInterface)
+// 	err = reader.Lookup(nil).Decode( recordInterface)
 // 	assert.Equal(t, "IP passed to Lookup cannot be nil", err.Error())
 // 	require.NoError(t, reader.Close(), "error on close")
 // }
@@ -647,7 +647,7 @@ func TestUsingClosedDatabase(t *testing.T) {
 
 	var recordInterface any
 	addr := netip.MustParseAddr("::")
-	err = reader.Lookup(addr, recordInterface)
+	err = reader.Lookup(addr).Decode(recordInterface)
 	assert.Equal(t, "cannot call Lookup on a closed database", err.Error())
 
 	_, err = reader.LookupOffset(addr)
@@ -688,7 +688,7 @@ func checkIpv4(t *testing.T, reader *Reader) {
 		ip := netip.MustParseAddr(address)
 
 		var result map[string]string
-		err := reader.Lookup(ip, &result)
+		err := reader.Lookup(ip).Decode(&result)
 		require.NoError(t, err, "unexpected error while doing lookup: %v", err)
 		assert.Equal(t, map[string]string{"ip": address}, result)
 	}
@@ -708,7 +708,7 @@ func checkIpv4(t *testing.T, reader *Reader) {
 		ip := netip.MustParseAddr(keyAddress)
 
 		var result map[string]string
-		err := reader.Lookup(ip, &result)
+		err := reader.Lookup(ip).Decode(&result)
 		require.NoError(t, err, "unexpected error while doing lookup: %v", err)
 		assert.Equal(t, data, result)
 	}
@@ -717,7 +717,7 @@ func checkIpv4(t *testing.T, reader *Reader) {
 		ip := netip.MustParseAddr(address)
 
 		var result map[string]string
-		err := reader.Lookup(ip, &result)
+		err := reader.Lookup(ip).Decode(&result)
 		require.NoError(t, err, "unexpected error while doing lookup: %v", err)
 		assert.Nil(t, result)
 	}
@@ -731,7 +731,7 @@ func checkIpv6(t *testing.T, reader *Reader) {
 
 	for _, address := range subnets {
 		var result map[string]string
-		err := reader.Lookup(netip.MustParseAddr(address), &result)
+		err := reader.Lookup(netip.MustParseAddr(address)).Decode(&result)
 		require.NoError(t, err, "unexpected error while doing lookup: %v", err)
 		assert.Equal(t, map[string]string{"ip": address}, result)
 	}
@@ -750,14 +750,14 @@ func checkIpv6(t *testing.T, reader *Reader) {
 	for keyAddress, valueAddress := range pairs {
 		data := map[string]string{"ip": valueAddress}
 		var result map[string]string
-		err := reader.Lookup(netip.MustParseAddr(keyAddress), &result)
+		err := reader.Lookup(netip.MustParseAddr(keyAddress)).Decode(&result)
 		require.NoError(t, err, "unexpected error while doing lookup: %v", err)
 		assert.Equal(t, data, result)
 	}
 
 	for _, address := range []string{"1.1.1.33", "255.254.253.123", "89fa::"} {
 		var result map[string]string
-		err := reader.Lookup(netip.MustParseAddr(address), &result)
+		err := reader.Lookup(netip.MustParseAddr(address)).Decode(&result)
 		require.NoError(t, err, "unexpected error while doing lookup: %v", err)
 		assert.Nil(t, result)
 	}
@@ -787,7 +787,7 @@ func BenchmarkInterfaceLookup(b *testing.B) {
 	s := make(net.IP, 4)
 	for i := 0; i < b.N; i++ {
 		ip := randomIPv4Address(r, s)
-		err = db.Lookup(ip, &result)
+		err = db.Lookup(ip).Decode(&result)
 		if err != nil {
 			b.Error(err)
 		}
@@ -875,7 +875,7 @@ func BenchmarkCityLookup(b *testing.B) {
 	s := make(net.IP, 4)
 	for i := 0; i < b.N; i++ {
 		ip := randomIPv4Address(r, s)
-		err = db.Lookup(ip, &result)
+		err = db.Lookup(ip).Decode(&result)
 		if err != nil {
 			b.Error(err)
 		}
@@ -919,7 +919,7 @@ func BenchmarkCountryCode(b *testing.B) {
 	s := make(net.IP, 4)
 	for i := 0; i < b.N; i++ {
 		ip := randomIPv4Address(r, s)
-		err = db.Lookup(ip, &result)
+		err = db.Lookup(ip).Decode(&result)
 		if err != nil {
 			b.Error(err)
 		}

--- a/result.go
+++ b/result.go
@@ -46,6 +46,51 @@ func (r Result) Decode(v any) error {
 	return err
 }
 
+// DecodePath unmarshals a value from data section into v, following the
+// specified path.
+//
+// The v parameter should be a pointer to the value where the decoded data
+// will be stored. If v is nil or not a pointer, an error is returned. If the
+// data in the database record cannot be stored in v because of type
+// differences, an UnmarshalTypeError is returned.
+//
+// The path is a variadic list of keys (strings) and/or indices (ints) that
+// describe the nested structure to traverse in the data to reach the desired
+// value.
+//
+// For maps, string path elements are used as keys.
+// For arrays, int path elements are used as indices.
+//
+// If the path is empty, the entire data structure is decoded into v.
+//
+// Returns an error if:
+//   - the path is invalid
+//   - the data cannot be decoded into the type of v
+//   - v is not a pointer or the database record cannot be stored in v due to
+//     type mismatch
+//   - the Result does not contain valid data
+//
+// Example usage:
+//
+//	var city string
+//	err := result.DecodePath(&city, "location", "city", "names", "en")
+//
+//	var geonameID int
+//	err := result.DecodePath(&geonameID, "subdivisions", 0, "geoname_id")
+func (r Result) DecodePath(v any, path ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	if r.offset == notFound {
+		return nil
+	}
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return errors.New("result param must be a pointer")
+	}
+	return r.decoder.decodePath(r.offset, path, rv)
+}
+
 // Err provides a way to check whether there was an error during the lookup
 // without clling Result.Decode. If there was an error, it will also be
 // returned from Result.Decode.

--- a/result.go
+++ b/result.go
@@ -1,0 +1,60 @@
+package maxminddb
+
+import (
+	"errors"
+	"math"
+	"reflect"
+)
+
+const notFound uint = math.MaxUint
+
+type Result struct {
+	err     error
+	decoder decoder
+	offset  uint
+}
+
+// Decode unmarshals the data from the data section into the value pointed to
+// by v. If v is nil or not a pointer, an error is returned. If the data in
+// the database record cannot be stored in v because of type differences, an
+// UnmarshalTypeError is returned. If the database is invalid or otherwise
+// cannot be read, an InvalidDatabaseError is returned.
+//
+// An error will also be returned if there was an error during the
+// Reader.Lookup call.
+//
+// If the Reader.Lookup call did not find a value for the IP address, no error
+// will be returned and v will be unchanged.
+func (r Result) Decode(v any) error {
+	if r.err != nil {
+		return r.err
+	}
+	if r.offset == notFound {
+		return nil
+	}
+	rv := reflect.ValueOf(v)
+	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+		return errors.New("result param must be a pointer")
+	}
+
+	if dser, ok := v.(deserializer); ok {
+		_, err := r.decoder.decodeToDeserializer(r.offset, dser, 0, false)
+		return err
+	}
+
+	_, err := r.decoder.decode(r.offset, rv, 0)
+	return err
+}
+
+// Err provides a way to check whether there was an error during the lookup
+// without clling Result.Decode. If there was an error, it will also be
+// returned from Result.Decode.
+func (r Result) Err() error {
+	return r.err
+}
+
+// Found will return true if the IP was found in the search tree. It will
+// return false if the IP was not found or if there was an error.
+func (r Result) Found() bool {
+	return r.err == nil && r.offset != notFound
+}

--- a/result.go
+++ b/result.go
@@ -95,7 +95,7 @@ func (r Result) DecodePath(v any, path ...any) error {
 }
 
 // Err provides a way to check whether there was an error during the lookup
-// without clling Result.Decode. If there was an error, it will also be
+// without calling Result.Decode. If there was an error, it will also be
 // returned from Result.Decode.
 func (r Result) Err() error {
 	return r.err
@@ -105,6 +105,17 @@ func (r Result) Err() error {
 // return false if the IP was not found or if there was an error.
 func (r Result) Found() bool {
 	return r.err == nil && r.offset != notFound
+}
+
+// RecordOffset returns the offset of the record in the database. This can be
+// passed to ReaderDecode. It can also be used as a unique identifier for the
+// data record in the particular database to cache the data record across
+// lookups. Note that while the offset uniquely identifies the data record,
+// other data in Result  may differ between lookups. The offset is only valid
+// for the current database version. If you update the database file, you must
+// invalidate any cache associated with the previous version.
+func (r Result) RecordOffset() uintptr {
+	return uintptr(r.offset)
 }
 
 // Network returns the netip.Prefix representing the network associated with


### PR DESCRIPTION
This allows for more flexibility without requiring adding a method to `Reader` for every possible variant.