### PR TITLE
Hardening and improved tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2.2.0 - TBD
 
+- Fixed lookups that followed malformed search-tree pointers past the data
+  section so they now fail during `Lookup` instead of surfacing a deferred
+  decode error.
 - An error is returned when a `maxminddb` struct tag is clearly invalid (non
   UTF-8) instead of silently ignoring validation failures.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2.2.0 - TBD
 
+- Fixed unsigned bounds checks in search-tree node reads and traversal so very
+  short malformed buffers return errors instead of underflowing the bounds
+  calculation.
 - Fixed the reflection decoder so pointer fields are not allocated when
   decoding fails with a type mismatch.
 - Fixed `Result.Prefix()` to use the reader's measured IPv4 subtree depth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.2.0 - TBD
 
+- Fixed `Result.Prefix()` to use the reader's measured IPv4 subtree depth
+  instead of assuming IPv4 records always start at bit 96 in IPv6 databases.
 - Fixed reflection decoding of negative `int32` values into unsigned Go fields
   so it now returns a type error instead of wrapping them to large integers.
 - Fixed lookups that followed malformed search-tree pointers past the data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.2.0 - TBD
 
+- Fixed verifier search-tree size arithmetic to match the reader's safe
+  multiplication order instead of using an overflow-prone equivalent formula.
 - Fixed unsigned bounds checks in search-tree node reads and traversal so very
   short malformed buffers return errors instead of underflowing the bounds
   calculation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.2.0 - TBD
 
+- Fixed the reflection decoder so pointer fields are not allocated when
+  decoding fails with a type mismatch.
 - Fixed `Result.Prefix()` to use the reader's measured IPv4 subtree depth
   instead of assuming IPv4 records always start at bit 96 in IPv6 databases.
 - Fixed reflection decoding of negative `int32` values into unsigned Go fields

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.2.0 - TBD
 
+- Improved reflection decoding performance by skipping `Unmarshaler` checks for
+  destination types that cannot implement the interface.
 - Fixed verifier search-tree size arithmetic to match the reader's safe
   multiplication order instead of using an overflow-prone equivalent formula.
 - Fixed unsigned bounds checks in search-tree node reads and traversal so very

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
   decode error.
 - An error is returned when a `maxminddb` struct tag is clearly invalid (non
   UTF-8) instead of silently ignoring validation failures.
+- Increased internal string cache size to 4096 entries to reduce cache thrashing
+  and improve concurrent performance.
 
 ## 2.1.1 - 2025-11-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.2.0 - TBD
 
+- Fixed reflection decoding of negative `int32` values into unsigned Go fields
+  so it now returns a type error instead of wrapping them to large integers.
 - Fixed lookups that followed malformed search-tree pointers past the data
   section so they now fail during `Lookup` instead of surfacing a deferred
   decode error.

--- a/bad_data_test.go
+++ b/bad_data_test.go
@@ -9,56 +9,71 @@ import (
 
 func TestBadDataFixtures(t *testing.T) {
 	tests := []struct {
-		name        string
-		openError   string
-		verifyError string
-		lookupIP    string
-		lookupError string
-		decodeError string
+		name             string
+		openError        string
+		verifyError      string
+		lookupIP         string
+		lookupError      string
+		decodeError      string
+		iterateCount     int
+		iterateError     string
+		iterateDecodeErr string
 	}{
 		{
-			name:        "libmaxminddb/libmaxminddb-corrupt-search-tree.mmdb",
-			verifyError: "description - Expected: non-empty map",
+			name:         "libmaxminddb/libmaxminddb-corrupt-search-tree.mmdb",
+			verifyError:  "description - Expected: non-empty map",
+			iterateCount: 2,
 		},
 		{
-			name:        "libmaxminddb/libmaxminddb-deep-array-nesting.mmdb",
-			verifyError: "description - Expected: non-empty map",
-			lookupIP:    "1.1.1.1",
-			decodeError: "exceeded maximum data structure depth",
+			name:             "libmaxminddb/libmaxminddb-deep-array-nesting.mmdb",
+			verifyError:      "description - Expected: non-empty map",
+			lookupIP:         "1.1.1.1",
+			decodeError:      "exceeded maximum data structure depth",
+			iterateCount:     2,
+			iterateDecodeErr: "exceeded maximum data structure depth",
 		},
 		{
-			name:        "libmaxminddb/libmaxminddb-deep-nesting.mmdb",
-			verifyError: "description - Expected: non-empty map",
-			lookupIP:    "1.1.1.1",
-			decodeError: "exceeded maximum data structure depth",
+			name:             "libmaxminddb/libmaxminddb-deep-nesting.mmdb",
+			verifyError:      "description - Expected: non-empty map",
+			lookupIP:         "1.1.1.1",
+			decodeError:      "exceeded maximum data structure depth",
+			iterateCount:     2,
+			iterateDecodeErr: "exceeded maximum data structure depth",
 		},
 		{
-			name:        "libmaxminddb/libmaxminddb-empty-array-last-in-metadata.mmdb",
-			verifyError: "description - Expected: non-empty map",
+			name:         "libmaxminddb/libmaxminddb-empty-array-last-in-metadata.mmdb",
+			verifyError:  "description - Expected: non-empty map",
+			iterateCount: 2,
 		},
 		{
-			name:        "libmaxminddb/libmaxminddb-empty-map-last-in-metadata.mmdb",
-			verifyError: "description - Expected: non-empty map",
+			name:         "libmaxminddb/libmaxminddb-empty-map-last-in-metadata.mmdb",
+			verifyError:  "description - Expected: non-empty map",
+			iterateCount: 2,
 		},
 		{
 			name:      "libmaxminddb/libmaxminddb-offset-integer-overflow.mmdb",
 			openError: "unexpected end of database",
 		},
 		{
-			name:        "libmaxminddb/libmaxminddb-oversized-array.mmdb",
-			verifyError: "description - Expected: non-empty map",
-			lookupIP:    "1.1.1.1",
-			decodeError: "unexpected end of database",
+			name:             "libmaxminddb/libmaxminddb-oversized-array.mmdb",
+			verifyError:      "description - Expected: non-empty map",
+			lookupIP:         "1.1.1.1",
+			decodeError:      "unexpected end of database",
+			iterateCount:     1,
+			iterateDecodeErr: "unexpected end of database",
 		},
 		{
-			name:        "libmaxminddb/libmaxminddb-oversized-map.mmdb",
-			verifyError: "description - Expected: non-empty map",
-			lookupIP:    "1.1.1.1",
-			decodeError: "unexpected end of database",
+			name:             "libmaxminddb/libmaxminddb-oversized-map.mmdb",
+			verifyError:      "description - Expected: non-empty map",
+			lookupIP:         "1.1.1.1",
+			decodeError:      "unexpected end of database",
+			iterateCount:     1,
+			iterateDecodeErr: "unexpected end of database",
 		},
 		{
-			name:        "libmaxminddb/libmaxminddb-uint64-max-epoch.mmdb",
-			verifyError: "description - Expected: non-empty map",
+			name:         "libmaxminddb/libmaxminddb-uint64-max-epoch.mmdb",
+			verifyError:  "description - Expected: non-empty map",
+			iterateCount: 2,
 		},
 		{
 			name:      "maxminddb-golang/cyclic-data-structure.mmdb",
@@ -89,11 +104,13 @@ func TestBadDataFixtures(t *testing.T) {
 			openError: "cannot unmarshal [] ([]uint8) into type []string",
 		},
 		{
-			name:        "maxminddb-python/bad-unicode-in-map-key.mmdb",
-			verifyError: "search tree is corrupt",
-			lookupIP:    "0.0.0.0",
-			lookupError: "search tree is corrupt",
-			decodeError: "search tree is corrupt",
+			name:         "maxminddb-python/bad-unicode-in-map-key.mmdb",
+			verifyError:  "search tree is corrupt",
+			lookupIP:     "0.0.0.0",
+			lookupError:  "search tree is corrupt",
+			decodeError:  "search tree is corrupt",
+			iterateCount: 1,
+			iterateError: "search tree is corrupt",
 		},
 	}
 
@@ -106,7 +123,9 @@ func TestBadDataFixtures(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			defer reader.Close()
+			t.Cleanup(func() {
+				require.NoError(t, reader.Close())
+			})
 
 			if tt.verifyError != "" {
 				require.ErrorContains(t, reader.Verify(), tt.verifyError)
@@ -126,10 +145,48 @@ func TestBadDataFixtures(t *testing.T) {
 			var value any
 			if tt.decodeError != "" {
 				require.ErrorContains(t, result.Decode(&value), tt.decodeError)
+			} else {
+				require.NoError(t, result.Decode(&value))
+			}
+
+			if tt.iterateCount == 0 {
 				return
 			}
 
-			require.NoError(t, result.Decode(&value))
+			count := 0
+			sawIterError := false
+			sawIterDecodeError := false
+			for iterResult := range reader.Networks(IncludeNetworksWithoutData()) {
+				count++
+				if tt.iterateError != "" && iterResult.Err() != nil {
+					require.ErrorContains(t, iterResult.Err(), tt.iterateError)
+					sawIterError = true
+					break
+				}
+
+				require.NoError(t, iterResult.Err())
+
+				var iterValue any
+				if tt.iterateDecodeErr != "" {
+					err = iterResult.Decode(&iterValue)
+					if err != nil {
+						require.ErrorContains(t, err, tt.iterateDecodeErr)
+						sawIterDecodeError = true
+						break
+					}
+					continue
+				}
+
+				require.NoError(t, iterResult.Decode(&iterValue))
+			}
+
+			require.Equal(t, tt.iterateCount, count)
+			if tt.iterateError != "" {
+				require.True(t, sawIterError)
+			}
+			if tt.iterateDecodeErr != "" {
+				require.True(t, sawIterDecodeError)
+			}
 		})
 	}
 }

--- a/bad_data_test.go
+++ b/bad_data_test.go
@@ -1,0 +1,135 @@
+package maxminddb
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBadDataFixtures(t *testing.T) {
+	tests := []struct {
+		name        string
+		openError   string
+		verifyError string
+		lookupIP    string
+		lookupError string
+		decodeError string
+	}{
+		{
+			name:        "libmaxminddb/libmaxminddb-corrupt-search-tree.mmdb",
+			verifyError: "description - Expected: non-empty map",
+		},
+		{
+			name:        "libmaxminddb/libmaxminddb-deep-array-nesting.mmdb",
+			verifyError: "description - Expected: non-empty map",
+			lookupIP:    "1.1.1.1",
+			decodeError: "exceeded maximum data structure depth",
+		},
+		{
+			name:        "libmaxminddb/libmaxminddb-deep-nesting.mmdb",
+			verifyError: "description - Expected: non-empty map",
+			lookupIP:    "1.1.1.1",
+			decodeError: "exceeded maximum data structure depth",
+		},
+		{
+			name:        "libmaxminddb/libmaxminddb-empty-array-last-in-metadata.mmdb",
+			verifyError: "description - Expected: non-empty map",
+		},
+		{
+			name:        "libmaxminddb/libmaxminddb-empty-map-last-in-metadata.mmdb",
+			verifyError: "description - Expected: non-empty map",
+		},
+		{
+			name:      "libmaxminddb/libmaxminddb-offset-integer-overflow.mmdb",
+			openError: "unexpected end of database",
+		},
+		{
+			name:        "libmaxminddb/libmaxminddb-oversized-array.mmdb",
+			verifyError: "description - Expected: non-empty map",
+			lookupIP:    "1.1.1.1",
+			decodeError: "unexpected end of database",
+		},
+		{
+			name:        "libmaxminddb/libmaxminddb-oversized-map.mmdb",
+			verifyError: "description - Expected: non-empty map",
+			lookupIP:    "1.1.1.1",
+			decodeError: "unexpected end of database",
+		},
+		{
+			name:        "libmaxminddb/libmaxminddb-uint64-max-epoch.mmdb",
+			verifyError: "description - Expected: non-empty map",
+		},
+		{
+			name:      "maxminddb-golang/cyclic-data-structure.mmdb",
+			openError: "path /record_size: unexpected end of database",
+		},
+		{
+			name:      "maxminddb-golang/invalid-bytes-length.mmdb",
+			openError: "path /description/en: unexpected end of database",
+		},
+		{
+			name:      "maxminddb-golang/invalid-data-record-offset.mmdb",
+			openError: "unexpected end of database",
+		},
+		{
+			name:      "maxminddb-golang/invalid-map-key-length.mmdb",
+			openError: "path /record_size: unexpected end of database",
+		},
+		{
+			name:      "maxminddb-golang/invalid-string-length.mmdb",
+			openError: "path /description: unexpected end of database",
+		},
+		{
+			name:      "maxminddb-golang/metadata-is-an-uint128.mmdb",
+			openError: "unexpected end of database",
+		},
+		{
+			name:      "maxminddb-golang/unexpected-bytes.mmdb",
+			openError: "cannot unmarshal [] ([]uint8) into type []string",
+		},
+		{
+			name:        "maxminddb-python/bad-unicode-in-map-key.mmdb",
+			verifyError: "search tree is corrupt",
+			lookupIP:    "0.0.0.0",
+			lookupError: "search tree is corrupt",
+			decodeError: "search tree is corrupt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader, err := Open(badDataFile(tt.name))
+			if tt.openError != "" {
+				require.ErrorContains(t, err, tt.openError)
+				return
+			}
+
+			require.NoError(t, err)
+			defer reader.Close()
+
+			if tt.verifyError != "" {
+				require.ErrorContains(t, reader.Verify(), tt.verifyError)
+			}
+
+			if tt.lookupIP == "" {
+				return
+			}
+
+			result := reader.Lookup(netip.MustParseAddr(tt.lookupIP))
+			if tt.lookupError != "" {
+				require.ErrorContains(t, result.Err(), tt.lookupError)
+			} else {
+				require.NoError(t, result.Err())
+			}
+
+			var value any
+			if tt.decodeError != "" {
+				require.ErrorContains(t, result.Decode(&value), tt.decodeError)
+				return
+			}
+
+			require.NoError(t, result.Decode(&value))
+		})
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -97,6 +97,7 @@ func ExampleReader_Networks() {
 	// 187.156.138.0/24: Cable/DSL
 	// 201.243.200.0/24: Corporate
 	// 207.179.48.0/20: Cellular
+	// 214.78.120.0/22: Satellite
 	// 216.160.83.56/29: Corporate
 	// 2003::/24: Cable/DSL
 }
@@ -128,7 +129,7 @@ func ExampleReader_Verify() {
 
 	// Output:
 	// Database type: GeoIP2-City
-	// Build time: 2022-07-26 14:53:10
+	// Build time: 2026-02-04 22:49:29
 	// IP version: IPv6
 	// Languages: [en zh]
 	// Description: GeoIP2 City Test Database (fake GeoIP2 data, for example purposes only)
@@ -238,10 +239,15 @@ func ExampleSkipEmptyValues() {
 	// Only networks with data:
 	// 1.2.0.0/16: map[is_anonymous:true is_anonymous_vpn:true]
 	// 1.124.213.1/32: map[is_anonymous:true is_anonymous_vpn:true is_tor_exit_node:true]
+	// 6.1.0.0/31: map[is_anonymous:true is_anonymous_vpn:true]
+	// 6.1.0.2/32: map[is_anonymous:true is_hosting_provider:true]
+	// 6.1.0.3/32: map[is_anonymous:true is_public_proxy:true]
+	// 6.1.0.4/32: map[is_anonymous:true is_residential_proxy:true]
 	// 65.0.0.0/13: map[is_anonymous:true is_tor_exit_node:true]
 	// 71.160.223.0/24: map[is_anonymous:true is_hosting_provider:true]
 	// 81.2.69.0/24: map[is_anonymous:true is_anonymous_vpn:true is_hosting_provider:true is_public_proxy:true is_residential_proxy:true is_tor_exit_node:true]
 	// 186.30.236.0/24: map[is_anonymous:true is_public_proxy:true]
+	// 2001:480:3a::/64: map[is_anonymous:true is_public_proxy:true]
 	// abcd:1000::/112: map[is_anonymous:true is_public_proxy:true]
 }
 

--- a/internal/decoder/reflection.go
+++ b/internal/decoder/reflection.go
@@ -466,6 +466,9 @@ func (d *ReflectionDecoder) unmarshalInt32(
 		reflect.Uint32,
 		reflect.Uint64,
 		reflect.Uintptr:
+		if value < 0 {
+			break
+		}
 		n := uint64(value)
 		if !result.OverflowUint(n) {
 			result.SetUint(n)

--- a/internal/decoder/reflection.go
+++ b/internal/decoder/reflection.go
@@ -247,12 +247,23 @@ func (d *ReflectionDecoder) decodeValue(
 	offset uint,
 	result addressableValue,
 	depth int,
-) (uint, error) {
+) (newOffset uint, retErr error) {
 	if depth > maximumDataStructureDepth {
 		return 0, mmdberrors.NewInvalidDatabaseError(
 			"exceeded maximum data structure depth; database is likely corrupt",
 		)
 	}
+
+	var allocatedPointers []reflect.Value
+	defer func() {
+		if retErr == nil {
+			return
+		}
+
+		for i := len(allocatedPointers) - 1; i >= 0; i-- {
+			allocatedPointers[i].SetZero()
+		}
+	}()
 
 	// Apply the original indirect logic to handle pointers and interfaces properly
 	for {
@@ -272,6 +283,7 @@ func (d *ReflectionDecoder) decodeValue(
 
 		if result.IsNil() {
 			result.Set(reflect.New(result.Type().Elem()))
+			allocatedPointers = append(allocatedPointers, result.Value)
 		}
 
 		result = addressableValue{
@@ -1245,7 +1257,17 @@ func (d *ReflectionDecoder) tryFastDecodeTyped(
 	case reflect.Ptr:
 		// Handle pointer to fast types
 		if result.IsNil() {
-			result.Set(reflect.New(expectedType.Elem()))
+			elem := reflect.New(expectedType.Elem()).Elem()
+			finalOffset, ok := d.tryFastDecodeTyped(
+				offset,
+				addressableValue{elem, false},
+				expectedType.Elem(),
+			)
+			if !ok {
+				return 0, false
+			}
+			result.Set(elem.Addr())
+			return finalOffset, true
 		}
 		return d.tryFastDecodeTyped(
 			offset,

--- a/internal/decoder/reflection.go
+++ b/internal/decoder/reflection.go
@@ -18,6 +18,8 @@ type Unmarshaler interface {
 	UnmarshalMaxMindDB(d *Decoder) error
 }
 
+var unmarshalerType = reflect.TypeFor[Unmarshaler]()
+
 // ReflectionDecoder is a decoder for the MMDB data section.
 type ReflectionDecoder struct {
 	DataDecoder
@@ -292,8 +294,9 @@ func (d *ReflectionDecoder) decodeValue(
 		} // dereferenced pointer is always addressable
 	}
 
-	// Check if the value implements Unmarshaler interface using type assertion
-	if result.CanAddr() {
+	// Skip the reflective type assertion when the destination type cannot
+	// implement Unmarshaler. This is the common case in normal struct decoding.
+	if result.CanAddr() && mayImplementUnmarshaler(result.Type()) {
 		if unmarshaler, ok := tryTypeAssert(result.Addr()); ok {
 			decoder := NewDecoder(d.DataDecoder, offset)
 			if err := unmarshaler.UnmarshalMaxMindDB(decoder); err != nil {
@@ -917,7 +920,24 @@ func handleEmbeddedField(
 	return !hasTag
 }
 
-var fieldsMap sync.Map
+var (
+	fieldsMap        sync.Map
+	unmarshalerCache sync.Map
+)
+
+func mayImplementUnmarshaler(t reflect.Type) bool {
+	if t.PkgPath() == "" || t.Kind() == reflect.Interface {
+		return false
+	}
+
+	if cached, ok := unmarshalerCache.Load(t); ok {
+		return cached.(bool)
+	}
+
+	implements := reflect.PointerTo(t).Implements(unmarshalerType)
+	unmarshalerCache.Store(t, implements)
+	return implements
+}
 
 func cachedFields(result reflect.Value) *fieldsType {
 	resultType := result.Type()

--- a/internal/decoder/reflection_test.go
+++ b/internal/decoder/reflection_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -66,6 +67,19 @@ func TestInt32(t *testing.T) {
 		"040180000001": int32(-2147483647),
 	}
 	validateDecoding(t, int32s)
+}
+
+func TestNegativeInt32DoesNotDecodeIntoUint(t *testing.T) {
+	inputBytes, err := hex.DecodeString("0401ffffffff")
+	require.NoError(t, err)
+
+	d := New(inputBytes)
+
+	var result uint64
+	err = d.Decode(0, &result)
+	require.Error(t, err)
+	assert.Equal(t, uint64(0), result)
+	assert.Contains(t, err.Error(), "cannot unmarshal -1 (int32) into type uint64")
 }
 
 func TestMap(t *testing.T) {

--- a/internal/decoder/reflection_test.go
+++ b/internal/decoder/reflection_test.go
@@ -82,6 +82,21 @@ func TestNegativeInt32DoesNotDecodeIntoUint(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot unmarshal -1 (int32) into type uint64")
 }
 
+func TestFastDecodePointerFieldDoesNotAllocateOnTypeError(t *testing.T) {
+	inputBytes, err := hex.DecodeString("e14173c101")
+	require.NoError(t, err)
+
+	d := New(inputBytes)
+
+	var result struct {
+		S *string `maxminddb:"s"`
+	}
+	err = d.Decode(0, &result)
+	require.Error(t, err)
+	assert.Nil(t, result.S)
+	assert.Contains(t, err.Error(), "cannot unmarshal 1 (uint64) into type string")
+}
+
 func TestMap(t *testing.T) {
 	maps := map[string]any{
 		"e0":                             map[string]any{},

--- a/internal/decoder/string_cache.go
+++ b/internal/decoder/string_cache.go
@@ -14,7 +14,7 @@ type cacheEntry struct {
 // stringCache provides bounded string interning with per-entry mutexes for minimal contention.
 // This achieves thread safety while avoiding the global lock bottleneck.
 type stringCache struct {
-	entries [512]cacheEntry
+	entries [4096]cacheEntry
 }
 
 // newStringCache creates a new per-entry mutex-based string cache.

--- a/reader.go
+++ b/reader.go
@@ -472,7 +472,7 @@ func readNodeBySize(buffer []byte, offset, bit, recordSize uint) (uint, error) {
 	switch recordSize {
 	case 24:
 		offset += bit * 3
-		if offset > bufferLen-3 {
+		if !hasBufferRange(bufferLen, offset, 3) {
 			return 0, mmdberrors.NewInvalidDatabaseError(
 				"bounds check failed: insufficient buffer for 24-bit node read",
 			)
@@ -482,7 +482,7 @@ func readNodeBySize(buffer []byte, offset, bit, recordSize uint) (uint, error) {
 			uint(buffer[offset+2]), nil
 	case 28:
 		if bit == 0 {
-			if offset > bufferLen-4 {
+			if !hasBufferRange(bufferLen, offset, 4) {
 				return 0, mmdberrors.NewInvalidDatabaseError(
 					"bounds check failed: insufficient buffer for 28-bit node read",
 				)
@@ -492,7 +492,7 @@ func readNodeBySize(buffer []byte, offset, bit, recordSize uint) (uint, error) {
 				(uint(buffer[offset+1]) << 8) |
 				uint(buffer[offset+2]), nil
 		}
-		if offset > bufferLen-7 {
+		if !hasBufferRange(bufferLen, offset, 7) {
 			return 0, mmdberrors.NewInvalidDatabaseError(
 				"bounds check failed: insufficient buffer for 28-bit node read",
 			)
@@ -503,7 +503,7 @@ func readNodeBySize(buffer []byte, offset, bit, recordSize uint) (uint, error) {
 			uint(buffer[offset+6]), nil
 	case 32:
 		offset += bit * 4
-		if offset > bufferLen-4 {
+		if !hasBufferRange(bufferLen, offset, 4) {
 			return 0, mmdberrors.NewInvalidDatabaseError(
 				"bounds check failed: insufficient buffer for 32-bit node read",
 			)
@@ -525,7 +525,7 @@ func readNodePairBySize(buffer []byte, baseOffset, recordSize uint) (left, right
 	switch recordSize {
 	case 24:
 		// Each child is 3 bytes; total 6 bytes starting at baseOffset
-		if baseOffset > bufferLen-6 {
+		if !hasBufferRange(bufferLen, baseOffset, 6) {
 			return 0, 0, mmdberrors.NewInvalidDatabaseError(
 				"bounds check failed: insufficient buffer for 24-bit node pair read",
 			)
@@ -538,7 +538,7 @@ func readNodePairBySize(buffer []byte, baseOffset, recordSize uint) (left, right
 	case 28:
 		// Left uses high nibble of shared byte, right uses low nibble.
 		// Layout: [A B C S][D E F] where S provides 4 shared bits for each child
-		if baseOffset > bufferLen-7 {
+		if !hasBufferRange(bufferLen, baseOffset, 7) {
 			return 0, 0, mmdberrors.NewInvalidDatabaseError(
 				"bounds check failed: insufficient buffer for 28-bit node pair read",
 			)
@@ -557,7 +557,7 @@ func readNodePairBySize(buffer []byte, baseOffset, recordSize uint) (left, right
 		return left, right, nil
 	case 32:
 		// Each child is 4 bytes; total 8 bytes
-		if baseOffset > bufferLen-8 {
+		if !hasBufferRange(bufferLen, baseOffset, 8) {
 			return 0, 0, mmdberrors.NewInvalidDatabaseError(
 				"bounds check failed: insufficient buffer for 32-bit node pair read",
 			)
@@ -613,7 +613,7 @@ func (r *Reader) traverseTree24(ip netip.Addr, node uint, stopBit int) (uint, in
 		baseOffset := node * 6
 		offset := baseOffset + bit*3
 
-		if offset > bufferLen-3 {
+		if !hasBufferRange(bufferLen, offset, 3) {
 			return 0, 0, mmdberrors.NewInvalidDatabaseError(
 				"bounds check failed during tree traversal",
 			)
@@ -646,7 +646,8 @@ func (r *Reader) traverseTree28(ip netip.Addr, node uint, stopBit int) (uint, in
 		baseOffset := node * 7
 		offset := baseOffset + bit*4
 
-		if baseOffset > bufferLen-4 || offset > bufferLen-3 {
+		if !hasBufferRange(bufferLen, baseOffset, 4) ||
+			!hasBufferRange(bufferLen, offset, 3) {
 			return 0, 0, mmdberrors.NewInvalidDatabaseError(
 				"bounds check failed during tree traversal",
 			)
@@ -685,7 +686,7 @@ func (r *Reader) traverseTree32(ip netip.Addr, node uint, stopBit int) (uint, in
 		baseOffset := node * 8
 		offset := baseOffset + bit*4
 
-		if offset > bufferLen-4 {
+		if !hasBufferRange(bufferLen, offset, 4) {
 			return 0, 0, mmdberrors.NewInvalidDatabaseError(
 				"bounds check failed during tree traversal",
 			)
@@ -698,6 +699,10 @@ func (r *Reader) traverseTree32(ip netip.Addr, node uint, stopBit int) (uint, in
 	}
 
 	return node, i, nil
+}
+
+func hasBufferRange(bufferLen, offset, size uint) bool {
+	return size <= bufferLen && offset <= bufferLen-size
 }
 
 func (r *Reader) resolveDataPointer(pointer uint) (uintptr, error) {

--- a/reader.go
+++ b/reader.go
@@ -140,8 +140,9 @@ type Reader struct {
 	buffer            []byte
 	Metadata          Metadata
 	ipv4Start         uint
-	ipv4StartBitDepth int
 	nodeOffsetMult    uint
+	dataSectionSize   uint
+	ipv4StartBitDepth int
 }
 
 // Metadata holds the metadata decoded from the MaxMind DB file.
@@ -354,12 +355,13 @@ func OpenBytes(buffer []byte, options ...ReaderOption) (*Reader, error) {
 	)
 
 	reader := &Reader{
-		buffer:         buffer,
-		decoder:        d,
-		Metadata:       metadata,
-		ipv4Start:      0,
-		nodeOffsetMult: metadata.RecordSize / 4,
-		hasMappedFile:  &atomic.Bool{},
+		buffer:          buffer,
+		dataSectionSize: dataSectionEnd - dataSectionStart,
+		decoder:         d,
+		Metadata:        metadata,
+		ipv4Start:       0,
+		nodeOffsetMult:  metadata.RecordSize / 4,
+		hasMappedFile:   &atomic.Bool{},
 	}
 
 	err = reader.setIPv4Start()
@@ -702,7 +704,7 @@ func (r *Reader) resolveDataPointer(pointer uint) (uintptr, error) {
 	}
 
 	resolved := uintptr(pointer - minPointer)
-	if resolved < uintptr(len(r.buffer)) {
+	if resolved < uintptr(r.dataSectionSize) {
 		return resolved, nil
 	}
 

--- a/reader.go
+++ b/reader.go
@@ -344,7 +344,7 @@ func OpenBytes(buffer []byte, options ...ReaderOption) (*Reader, error) {
 		}
 	}
 
-	searchTreeSize := metadata.NodeCount * (metadata.RecordSize / 4)
+	searchTreeSize := searchTreeSizeBytes(metadata.NodeCount, metadata.RecordSize)
 	dataSectionStart := searchTreeSize + dataSectionSeparatorSize
 	dataSectionEnd := uint(metadataStart - len(metadataStartMarker))
 	if dataSectionStart > dataSectionEnd {
@@ -370,6 +370,10 @@ func OpenBytes(buffer []byte, options ...ReaderOption) (*Reader, error) {
 	}
 
 	return reader, nil
+}
+
+func searchTreeSizeBytes(nodeCount, recordSize uint) uint {
+	return nodeCount * (recordSize / 4)
 }
 
 // Lookup retrieves the database record for ip and returns a Result, which can

--- a/reader.go
+++ b/reader.go
@@ -436,6 +436,10 @@ func (r *Reader) setIPv4Start() error {
 	return nil
 }
 
+func (r *Reader) hasIPv4Subtree() bool {
+	return r.Metadata.IPVersion == 4 || r.ipv4Start < r.Metadata.NodeCount
+}
+
 var zeroIP = netip.MustParseAddr("::")
 
 func (r *Reader) lookupPointer(ip netip.Addr) (uint, int, error) {

--- a/reader_bounds_test.go
+++ b/reader_bounds_test.go
@@ -1,0 +1,88 @@
+package maxminddb
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadNodeBySizeRejectsShortBuffers(t *testing.T) {
+	tests := []struct {
+		name       string
+		buffer     []byte
+		recordSize uint
+		bit        uint
+	}{
+		{name: "24-bit", buffer: []byte{0x01, 0x02}, recordSize: 24},
+		{name: "28-bit left", buffer: []byte{0x01, 0x02, 0x03}, recordSize: 28},
+		{
+			name:       "28-bit right",
+			buffer:     []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06},
+			recordSize: 28,
+			bit:        1,
+		},
+		{name: "32-bit", buffer: []byte{0x01, 0x02, 0x03}, recordSize: 32},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := readNodeBySize(tt.buffer, 0, tt.bit, tt.recordSize)
+			require.ErrorContains(t, err, "bounds check failed")
+		})
+	}
+}
+
+func TestReadNodePairBySizeRejectsShortBuffers(t *testing.T) {
+	tests := []struct {
+		name       string
+		buffer     []byte
+		recordSize uint
+	}{
+		{name: "24-bit", buffer: []byte{0x01, 0x02, 0x03, 0x04, 0x05}, recordSize: 24},
+		{name: "28-bit", buffer: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06}, recordSize: 28},
+		{name: "32-bit", buffer: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}, recordSize: 32},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := readNodePairBySize(tt.buffer, 0, tt.recordSize)
+			require.ErrorContains(t, err, "bounds check failed")
+		})
+	}
+}
+
+func TestTraverseTreeRejectsShortBuffers(t *testing.T) {
+	tests := []struct {
+		name       string
+		buffer     []byte
+		recordSize uint
+	}{
+		{name: "24-bit", buffer: []byte{0x01, 0x02}, recordSize: 24},
+		{name: "28-bit", buffer: []byte{0x01, 0x02, 0x03}, recordSize: 28},
+		{name: "32-bit", buffer: []byte{0x01, 0x02, 0x03}, recordSize: 32},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := &Reader{
+				buffer:   tt.buffer,
+				Metadata: Metadata{NodeCount: 1, RecordSize: tt.recordSize},
+			}
+			ip := netip.MustParseAddr("1.1.1.1")
+
+			var err error
+			switch tt.recordSize {
+			case 24:
+				_, _, err = reader.traverseTree24(ip, 0, 1)
+			case 28:
+				_, _, err = reader.traverseTree28(ip, 0, 1)
+			case 32:
+				_, _, err = reader.traverseTree32(ip, 0, 1)
+			default:
+				t.Fatalf("unexpected record size %d", tt.recordSize)
+			}
+			require.ErrorContains(t, err, "bounds check failed")
+		})
+	}
+}

--- a/reader_data_pointer_test.go
+++ b/reader_data_pointer_test.go
@@ -1,0 +1,48 @@
+package maxminddb
+
+import (
+	"bytes"
+	"net/netip"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLookupRejectsDataPointersOutsideDataSection(t *testing.T) {
+	buffer, err := os.ReadFile(testFile("MaxMind-DB-test-ipv4-24.mmdb"))
+	require.NoError(t, err)
+
+	reader, err := OpenBytes(buffer)
+	require.NoError(t, err)
+
+	metadataStart := bytes.LastIndex(buffer, metadataStartMarker)
+	require.NotEqual(t, -1, metadataStart)
+
+	searchTreeSize := int(searchTreeSizeBytes(
+		reader.Metadata.NodeCount,
+		reader.Metadata.RecordSize,
+	))
+	dataSectionLen := metadataStart - searchTreeSize - dataSectionSeparatorSize
+	require.Positive(t, dataSectionLen)
+
+	badPointer := uint(dataSectionLen) + reader.Metadata.NodeCount + dataSectionSeparatorSize
+	require.Greater(t, badPointer, reader.Metadata.NodeCount)
+	require.NoError(t, reader.Close())
+
+	buffer[0] = byte(badPointer >> 16)
+	buffer[1] = byte(badPointer >> 8)
+	buffer[2] = byte(badPointer)
+
+	reader, err = OpenBytes(buffer)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, reader.Close())
+	})
+
+	result := reader.Lookup(netip.MustParseAddr("0.0.0.1"))
+	require.EqualError(t, result.Err(), "the MaxMind DB file's search tree is corrupt")
+
+	var record any
+	require.EqualError(t, result.Decode(&record), "the MaxMind DB file's search tree is corrupt")
+}

--- a/reader_test.go
+++ b/reader_test.go
@@ -206,21 +206,21 @@ func TestLookupNetwork(t *testing.T) {
 			IP:              netip.MustParseAddr("200.0.2.1"),
 			DBFile:          "MaxMind-DB-no-ipv4-search-tree.mmdb",
 			ExpectedNetwork: "::/64",
-			ExpectedRecord:  "::0/64",
+			ExpectedRecord:  "::/64",
 			ExpectedFound:   true,
 		},
 		{
 			IP:              netip.MustParseAddr("::200.0.2.1"),
 			DBFile:          "MaxMind-DB-no-ipv4-search-tree.mmdb",
 			ExpectedNetwork: "::/64",
-			ExpectedRecord:  "::0/64",
+			ExpectedRecord:  "::/64",
 			ExpectedFound:   true,
 		},
 		{
 			IP:              netip.MustParseAddr("0:0:0:0:ffff:ffff:ffff:ffff"),
 			DBFile:          "MaxMind-DB-no-ipv4-search-tree.mmdb",
 			ExpectedNetwork: "::/64",
-			ExpectedRecord:  "::0/64",
+			ExpectedRecord:  "::/64",
 			ExpectedFound:   true,
 		},
 		{
@@ -712,6 +712,25 @@ func TestInvalidNodeCountDatabase(t *testing.T) {
 	assert.Equal(t, expected, err)
 }
 
+func TestDecodeDeeplyNestedBadData(t *testing.T) {
+	tests := []string{
+		"libmaxminddb/libmaxminddb-deep-array-nesting.mmdb",
+		"libmaxminddb/libmaxminddb-deep-nesting.mmdb",
+	}
+
+	for _, file := range tests {
+		t.Run(file, func(t *testing.T) {
+			reader, err := Open(badDataFile(file))
+			require.NoError(t, err)
+			defer reader.Close()
+
+			var result any
+			err = reader.Lookup(netip.MustParseAddr("1.1.1.1")).Decode(&result)
+			require.ErrorContains(t, err, "exceeded maximum data structure depth")
+		})
+	}
+}
+
 func TestMissingDatabase(t *testing.T) {
 	reader, err := Open("file-does-not-exist.mmdb")
 	assert.Nil(t, reader, "received reader when doing lookups on DB that doesn't exist")
@@ -769,9 +788,9 @@ func checkMetadata(t *testing.T, reader *Reader, ipVersion, recordSize uint) {
 	assert.Equal(t, []string{"en", "zh"}, metadata.Languages)
 
 	if ipVersion == 4 {
-		assert.Equal(t, uint(164), metadata.NodeCount)
+		assert.Equal(t, uint(163), metadata.NodeCount)
 	} else {
-		assert.Equal(t, uint(416), metadata.NodeCount)
+		assert.Equal(t, uint(415), metadata.NodeCount)
 	}
 
 	assert.Equal(t, recordSize, metadata.RecordSize)
@@ -1111,6 +1130,10 @@ func randomIPv4Address(r *rand.Rand, ip []byte) netip.Addr {
 
 func testFile(file string) string {
 	return filepath.Join("test-data", "test-data", file)
+}
+
+func badDataFile(file string) string {
+	return filepath.Join("test-data", "bad-data", file)
 }
 
 // Test custom unmarshaling through Reader.Lookup.

--- a/reader_test.go
+++ b/reader_test.go
@@ -712,25 +712,6 @@ func TestInvalidNodeCountDatabase(t *testing.T) {
 	assert.Equal(t, expected, err)
 }
 
-func TestDecodeDeeplyNestedBadData(t *testing.T) {
-	tests := []string{
-		"libmaxminddb/libmaxminddb-deep-array-nesting.mmdb",
-		"libmaxminddb/libmaxminddb-deep-nesting.mmdb",
-	}
-
-	for _, file := range tests {
-		t.Run(file, func(t *testing.T) {
-			reader, err := Open(badDataFile(file))
-			require.NoError(t, err)
-			defer reader.Close()
-
-			var result any
-			err = reader.Lookup(netip.MustParseAddr("1.1.1.1")).Decode(&result)
-			require.ErrorContains(t, err, "exceeded maximum data structure depth")
-		})
-	}
-}
-
 func TestMissingDatabase(t *testing.T) {
 	reader, err := Open("file-does-not-exist.mmdb")
 	assert.Nil(t, reader, "received reader when doing lookups on DB that doesn't exist")

--- a/result.go
+++ b/result.go
@@ -126,19 +126,28 @@ func (r Result) Prefix() netip.Prefix {
 	prefixLen := int(r.prefixLen)
 
 	if ip.Is4() {
-		// This is necessary as the node that the IPv4 start is at may
-		// be at a bit depth that is less that 96, i.e., ipv4Start points
-		// to a leaf node. For instance, if a record was inserted at ::/8,
-		// the ipv4Start would point directly at the leaf node for the
-		// record and would have a bit depth of 8. This would not happen
-		// with databases currently distributed by MaxMind as all of them
-		// have an IPv4 subtree that is greater than a single node.
-		if prefixLen < 96 {
+		var isIPv4 bool
+		prefixLen, isIPv4 = r.ipv4PrefixLen(prefixLen)
+		if !isIPv4 {
 			return netip.PrefixFrom(zeroIP, prefixLen)
 		}
-		prefixLen -= 96
 	}
 
 	prefix, _ := ip.Prefix(prefixLen)
 	return prefix
+}
+
+func (r Result) ipv4PrefixLen(prefixLen int) (int, bool) {
+	if r.reader != nil && r.reader.hasIPv4Subtree() {
+		if prefixLen < r.reader.ipv4StartBitDepth {
+			return prefixLen, false
+		}
+		return prefixLen - r.reader.ipv4StartBitDepth, true
+	}
+
+	if prefixLen < 96 {
+		return prefixLen, false
+	}
+
+	return prefixLen - 96, true
 }

--- a/result_test.go
+++ b/result_test.go
@@ -1,0 +1,40 @@
+package maxminddb
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResultPrefixUsesIPv4StartBitDepth(t *testing.T) {
+	reader := &Reader{
+		Metadata:          Metadata{IPVersion: 6, NodeCount: 8},
+		ipv4Start:         4,
+		ipv4StartBitDepth: 64,
+	}
+
+	result := Result{
+		reader:    reader,
+		ip:        netip.MustParseAddr("1.2.3.4"),
+		prefixLen: 88,
+	}
+
+	assert.Equal(t, "1.2.3.0/24", result.Prefix().String())
+}
+
+func TestResultPrefixReturnsIPv6NetworkWithoutIPv4Subtree(t *testing.T) {
+	reader := &Reader{
+		Metadata:          Metadata{IPVersion: 6, NodeCount: 8},
+		ipv4Start:         8,
+		ipv4StartBitDepth: 64,
+	}
+
+	result := Result{
+		reader:    reader,
+		ip:        netip.MustParseAddr("1.2.3.4"),
+		prefixLen: 64,
+	}
+
+	assert.Equal(t, "::/64", result.Prefix().String())
+}

--- a/verifier.go
+++ b/verifier.go
@@ -127,7 +127,10 @@ func (v *verifier) verifySearchTree() (map[uint]bool, error) {
 }
 
 func (v *verifier) verifyDataSectionSeparator() error {
-	separatorStart := v.reader.Metadata.NodeCount * v.reader.Metadata.RecordSize / 4
+	separatorStart := searchTreeSizeBytes(
+		v.reader.Metadata.NodeCount,
+		v.reader.Metadata.RecordSize,
+	)
 	separatorEnd := separatorStart + dataSectionSeparatorSize
 	if separatorEnd < separatorStart || separatorEnd > uint(len(v.reader.buffer)) {
 		return mmdberrors.NewInvalidDatabaseError(

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -78,3 +78,10 @@ func TestVerifyDataSectionSeparatorOutOfBounds(t *testing.T) {
 		assert.ErrorContains(t, err, "unexpected end of database")
 	})
 }
+
+func TestSearchTreeSizeBytesUsesSafeMultiplicationOrder(t *testing.T) {
+	nodeCount := ^uint(0)/16 + 1
+
+	assert.Equal(t, nodeCount*8, searchTreeSizeBytes(nodeCount, 32))
+	assert.NotEqual(t, (nodeCount*32)/4, searchTreeSizeBytes(nodeCount, 32))
+}


### PR DESCRIPTION
- **Refresh test fixtures and expectations**
- **Reject data pointers beyond the data section**
- **Reject negative int32 values for unsigned fields**
- **Use reader IPv4 subtree depth for prefixes**
- **Cover all malformed database fixtures**
- **Avoid allocating pointer fields on decode errors**
- **Harden search tree bounds checks**
- **Align verifier tree size arithmetic**
- **Exercise iteration on malformed fixtures**
- **Skip impossible Unmarshaler checks**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected IPv4 prefix calculations and made lookups fail earlier for malformed search-tree pointers.
  * Fixed numeric decode errors (negative int32 → unsigned) and avoided allocating pointer fields on failed type-mismatch decodes.
  * Tightened bounds checks to error on very short/malformed buffers.

* **Tests**
  * Added comprehensive bad-data, bounds, pointer-corruption, reflection, and prefix tests covering error paths.

* **Performance**
  * Increased internal string cache capacity to reduce collisions.

* **Documentation**
  * Updated changelog with behavioral and performance notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->