### PR TITLE
Skip uint64-max-epoch test on 32-bit architectures

### DIFF
--- a/bad_data_test.go
+++ b/bad_data_test.go
@@ -1,6 +1,7 @@
 package maxminddb
 
 import (
+	"math/bits"
 	"net/netip"
 	"testing"
 
@@ -116,6 +117,15 @@ func TestBadDataFixtures(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Skip uint64-max-epoch test on 32-bit architectures: the test fails as
+			// BuildEpoch is defined as a uint type (ie. 32 bits), leading to error:
+			// cannot unmarshal 18446744073709551615 (uint64) into type uint
+			if bits.UintSize == 32 {
+				if tt.name == "libmaxminddb/libmaxminddb-uint64-max-epoch.mmdb" {
+					t.Skip("Skipping on 32-bit architectures")
+				}
+			}
+
 			reader, err := Open(badDataFile(tt.name))
 			if tt.openError != "" {
 				require.ErrorContains(t, err, tt.openError)


### PR DESCRIPTION
This test is documented in test-data/bad-data/README.md:

> Note: `libmaxminddb/libmaxminddb-uint64-max-epoch.mmdb` contains a
> valid database structure with `build_epoch` set to `UINT64_MAX`. It
> may not produce a reader error but can cause overflow in time type
> conversions.

Inded it fails on 32-bit architectures with the following error:

```
cannot unmarshal 18446744073709551615 (uint64) into type uint
```

This is caused by the fact that the field BuildEpoch in the Metadata struct is defined as a uint, not a uint64, and the size of a uint is likely to be 32 bits on 32-bits architectures.

Unfortunately, changing the BuildEpoch to be a uint64 is a breaking change, so for now all we can do is to skip the test.

Closes: #208

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite to conditionally skip specific test cases on 32-bit architectures, improving compatibility and test execution on different platform configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->