### PR TITLE
Performance improvements for reflection decoding and IPv4 tree walk

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        go-version: [1.24, 1.25]
+        go-version: [1.26, 1.25]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,8 @@ linters:
       comparison: true
     exhaustive:
       default-signifies-exhaustive: true
+    goconst:
+      ignore-tests: true
     forbidigo:
       forbid:
         - pattern: Geoip

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.24"
+  go: "1.25"
   tests: true
   allow-parallel-runners: true
 linters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.3.0
 
+- This module now targets Go 1.25+.
 - Reduced reflection decoding time and heap allocations on the hot path. A
   city-lookup benchmark decoding a geoip2-style result runs about 15% faster
   and allocates about 39% fewer bytes per lookup compared to 2.2.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changes
 
+## 2.3.0
+
+- Reduced reflection decoding time and heap allocations on the hot path. A
+  city-lookup benchmark decoding a geoip2-style result runs about 15% faster
+  and allocates about 39% fewer bytes per lookup compared to 2.2.0.
+- Specialized the IPv4 search-tree walk for 24-, 28-, and 32-bit record
+  sizes to skip the IPv6 prefix when looking up IPv4 addresses.
+- Decoding into a non-nil slice with sufficient capacity now reuses the
+  caller's backing array instead of allocating a fresh slice, matching
+  `encoding/json` semantics. Callers that share slice headers across
+  `Decode` calls should be aware that the backing memory is now mutated.
+- Reduced contention under concurrent lookups by switching the internal string
+  cache to a lock-free design.
+
 ## 2.2.0 - 2026-04-26
 
 - Improved reflection decoding performance by skipping `Unmarshaler` checks for

--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ Version 2.0 includes significant improvements:
 - **Network Iteration**: Iterate over all networks in a database with
   `Networks()` and `NetworksWithin()`
 - **Enhanced Performance**: Optimized data structures and decoding paths
-- **Go 1.24+ Support**: Takes advantage of modern Go features including
-  iterators
 - **Better Error Handling**: More detailed error types and improved debugging
 - **Integrity Checks**: Validate databases with `Reader.Verify()` and access
   metadata helpers such as `Metadata.BuildTime()`
@@ -247,7 +245,7 @@ Download from
 
 ## Requirements
 
-- Go 1.24 or later
+- Go 1.25 or later
 - MaxMind DB file in .mmdb format
 
 ## Contributing

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oschwald/maxminddb-golang/v2
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/stretchr/testify v1.11.1

--- a/internal/decoder/data_decoder.go
+++ b/internal/decoder/data_decoder.go
@@ -402,6 +402,24 @@ func append64(val uint64, b byte) (uint64, byte) {
 // copying the bytes when decoding a struct. Previously, we achieved this by
 // using unsafe.
 func (d *DataDecoder) decodeKey(offset uint) ([]byte, uint, error) {
+	bufferLen := uint(len(d.buffer))
+	if offset >= bufferLen {
+		return nil, 0, mmdberrors.NewOffsetError()
+	}
+
+	ctrlByte := d.buffer[offset]
+	if Kind(ctrlByte>>5) == KindString {
+		size := uint(ctrlByte & 0x1f)
+		if size < 29 {
+			dataOffset := offset + 1
+			newOffset := dataOffset + size
+			if newOffset > bufferLen {
+				return nil, 0, mmdberrors.NewOffsetError()
+			}
+			return d.buffer[dataOffset:newOffset], newOffset, nil
+		}
+	}
+
 	kindNum, size, dataOffset, err := d.decodeCtrlData(offset)
 	if err != nil {
 		return nil, 0, err
@@ -438,7 +456,7 @@ func (d *DataDecoder) decodeKey(offset uint) ([]byte, uint, error) {
 		)
 	}
 	newOffset := dataOffset + size
-	if newOffset > uint(len(d.buffer)) {
+	if newOffset > bufferLen {
 		return nil, 0, mmdberrors.NewOffsetError()
 	}
 	return d.buffer[dataOffset:newOffset], nextOffset, nil

--- a/internal/decoder/data_decoder.go
+++ b/internal/decoder/data_decoder.go
@@ -131,25 +131,50 @@ func (d *DataDecoder) getBuffer() []byte {
 }
 
 // decodeCtrlData decodes the control byte and data info at the given offset.
+// Encoding follows the MaxMind DB spec: the control byte's high 3 bits
+// encode the type (or KindExtended if zero, in which case the next byte
+// holds kind-7 and the decoder adds 7 back), and the low 5 bits encode
+// size. Sizes 0..28 are encoded directly; 29 reads 1 extra byte (+29),
+// 30 reads 2 (+285), and 31 reads 3 (+65821).
 func (d *DataDecoder) decodeCtrlData(offset uint) (Kind, uint, uint, error) {
+	bufferLen := uint(len(d.buffer))
 	newOffset := offset + 1
-	if offset >= uint(len(d.buffer)) {
+	if offset >= bufferLen {
 		return 0, 0, 0, mmdberrors.NewOffsetError()
 	}
 	ctrlByte := d.buffer[offset]
 
 	kindNum := Kind(ctrlByte >> 5)
 	if kindNum == KindExtended {
-		if newOffset >= uint(len(d.buffer)) {
+		if newOffset >= bufferLen {
 			return 0, 0, 0, mmdberrors.NewOffsetError()
 		}
 		kindNum = Kind(d.buffer[newOffset] + 7)
 		newOffset++
 	}
 
-	var size uint
-	size, newOffset, err := d.sizeFromCtrlByte(ctrlByte, newOffset, kindNum)
-	return kindNum, size, newOffset, err
+	size := uint(ctrlByte & 0x1f)
+	if size < 29 {
+		return kindNum, size, newOffset, nil
+	}
+
+	endOffset := newOffset + size - 28
+	if endOffset > bufferLen {
+		return 0, 0, 0, mmdberrors.NewOffsetError()
+	}
+
+	switch size {
+	case 29:
+		return kindNum, 29 + uint(d.buffer[newOffset]), newOffset + 1, nil
+	case 30:
+		value := uint(d.buffer[newOffset])<<8 | uint(d.buffer[newOffset+1])
+		return kindNum, 285 + value, endOffset, nil
+	default: // size == 31
+		value := uint(d.buffer[newOffset])<<16 |
+			uint(d.buffer[newOffset+1])<<8 |
+			uint(d.buffer[newOffset+2])
+		return kindNum, 65821 + value, endOffset, nil
+	}
 }
 
 // decodeBytes decodes a byte slice from the given offset with the given size.
@@ -453,43 +478,6 @@ func (d *DataDecoder) nextValueOffset(offset, numberToSkip uint) (uint, error) {
 		numberToSkip--
 	}
 	return offset, nil
-}
-
-func (d *DataDecoder) sizeFromCtrlByte(
-	ctrlByte byte,
-	offset uint,
-	kindNum Kind,
-) (uint, uint, error) {
-	size := uint(ctrlByte & 0x1f)
-	if kindNum == KindExtended {
-		return size, offset, nil
-	}
-
-	var bytesToRead uint
-	if size < 29 {
-		return size, offset, nil
-	}
-
-	bytesToRead = size - 28
-	newOffset := offset + bytesToRead
-	if newOffset > uint(len(d.buffer)) {
-		return 0, 0, mmdberrors.NewOffsetError()
-	}
-	if size == 29 {
-		return 29 + uint(d.buffer[offset]), offset + 1, nil
-	}
-
-	sizeBytes := d.buffer[offset:newOffset]
-
-	switch {
-	case size == 30:
-		size = 285 + uintFromBytes(0, sizeBytes)
-	case size > 30:
-		size = uintFromBytes(0, sizeBytes) + 65821
-	default:
-		// size < 30, no modification needed
-	}
-	return size, newOffset, nil
 }
 
 func decodeBool(size, offset uint) (bool, uint) {

--- a/internal/decoder/data_decoder_test.go
+++ b/internal/decoder/data_decoder_test.go
@@ -1,0 +1,134 @@
+package decoder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDecodeCtrlData verifies all four size-encoding paths
+// (inline, +29, +285, +65821) plus the extended-kind path. Each path
+// also has a truncated-buffer case to exercise the bounds check that
+// guards reads of the extra size bytes.
+func TestDecodeCtrlData(t *testing.T) {
+	tests := []struct {
+		name       string
+		buffer     []byte
+		wantKind   Kind
+		wantSize   uint
+		wantOffset uint
+	}{
+		{
+			name:       "inline size (string size=5)",
+			buffer:     []byte{0x45, 'h', 'e', 'l', 'l', 'o'},
+			wantKind:   KindString,
+			wantSize:   5,
+			wantOffset: 1,
+		},
+		{
+			name:       "size 29 marker reads 1 byte (size=29+0=29)",
+			buffer:     append([]byte{0x5D, 0x00}, make([]byte, 29)...),
+			wantKind:   KindString,
+			wantSize:   29,
+			wantOffset: 2,
+		},
+		{
+			name:       "size 29 marker reads 1 byte (size=29+255=284)",
+			buffer:     append([]byte{0x5D, 0xFF}, make([]byte, 284)...),
+			wantKind:   KindString,
+			wantSize:   284,
+			wantOffset: 2,
+		},
+		{
+			name:       "size 30 marker reads 2 bytes (size=285+258=543)",
+			buffer:     append([]byte{0x5E, 0x01, 0x02}, make([]byte, 543)...),
+			wantKind:   KindString,
+			wantSize:   543,
+			wantOffset: 3,
+		},
+		{
+			name:       "size 31 marker reads 3 bytes (size=65821+66051=131872)",
+			buffer:     append([]byte{0x5F, 0x01, 0x02, 0x03}, make([]byte, 131872)...),
+			wantKind:   KindString,
+			wantSize:   131872,
+			wantOffset: 4,
+		},
+		{
+			name:       "extended kind (0x04 -> KindSlice, size=5 inline)",
+			buffer:     []byte{0x05, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00},
+			wantKind:   KindSlice,
+			wantSize:   5,
+			wantOffset: 2,
+		},
+		{
+			name:       "extended kind with size 29 marker (KindSlice, size=29+0=29)",
+			buffer:     append([]byte{0x1D, 0x04, 0x00}, make([]byte, 29)...),
+			wantKind:   KindSlice,
+			wantSize:   29,
+			wantOffset: 3,
+		},
+		{
+			name:       "extended kind with size 30 marker (KindSlice, size=285+256=541)",
+			buffer:     append([]byte{0x1E, 0x04, 0x01, 0x00}, make([]byte, 541)...),
+			wantKind:   KindSlice,
+			wantSize:   541,
+			wantOffset: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewDataDecoder(tt.buffer)
+			gotKind, gotSize, gotOffset, err := d.decodeCtrlData(0)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantKind, gotKind, "kind")
+			require.Equal(t, tt.wantSize, gotSize, "size")
+			require.Equal(t, tt.wantOffset, gotOffset, "newOffset")
+		})
+	}
+}
+
+// TestDecodeCtrlDataTruncated exercises the bounds checks: each case
+// has just enough bytes to start decoding but not enough to read the
+// trailing size or extended-kind byte(s).
+func TestDecodeCtrlDataTruncated(t *testing.T) {
+	tests := []struct {
+		name   string
+		buffer []byte
+	}{
+		{name: "empty buffer", buffer: []byte{}},
+		{name: "size 29 missing extra byte", buffer: []byte{0x5D}},
+		{name: "size 30 with only 1 of 2 extra bytes", buffer: []byte{0x5E, 0x00}},
+		{name: "size 31 with only 2 of 3 extra bytes", buffer: []byte{0x5F, 0x00, 0x00}},
+		{name: "extended kind missing kind byte", buffer: []byte{0x00}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewDataDecoder(tt.buffer)
+			_, _, _, err := d.decodeCtrlData(0)
+			require.Error(t, err)
+		})
+	}
+}
+
+// TestDecodeKeyFollowsPointer verifies that a pointer control byte at the
+// key position bypasses the fast path and is followed to the target string.
+// A regression that took the fast path on a non-KindString ctrl byte would
+// interpret the pointer payload byte as string data.
+func TestDecodeKeyFollowsPointer(t *testing.T) {
+	// Pointer (ctrl 0x20: high 3 bits = KindPointer, low 5 = pointerSize-1=0
+	// and prefix=0) plus payload 0x05 points to offset 5. The pointed-to
+	// data is a 3-byte string "key" (ctrl 0x43).
+	buf := []byte{
+		0x20, 0x05,
+		0x00, 0x00, 0x00,
+		0x43, 'k', 'e', 'y',
+	}
+	d := NewDataDecoder(buf)
+	got, nextOffset, err := d.decodeKey(0)
+	require.NoError(t, err)
+	require.Equal(t, "key", string(got))
+	require.Equal(t, uint(2), nextOffset,
+		"nextOffset should point past the pointer bytes, not past the pointed-to string")
+}

--- a/internal/decoder/data_decoder_test.go
+++ b/internal/decoder/data_decoder_test.go
@@ -1,6 +1,7 @@
 package decoder
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -110,6 +111,52 @@ func TestDecodeCtrlDataTruncated(t *testing.T) {
 			require.Error(t, err)
 		})
 	}
+}
+
+// TestDecodeKeyFastPathBoundary covers the 28/29-character boundary
+// between decodeKey's inline fast path (size < 29) and its slow path
+// (size >= 29). An off-by-one in the fast-path size check would either
+// pull a stale byte from the buffer (slow path size confused with fast
+// path data) or read past the end on a truncated input.
+func TestDecodeKeyFastPathBoundary(t *testing.T) {
+	tests := []struct {
+		name string
+		size int
+	}{
+		{name: "size 0 (fast-path min)", size: 0},
+		{name: "size 28 (fast-path max)", size: 28},
+		{name: "size 29 (slow-path min)", size: 29},
+		{name: "size 30 (slow-path)", size: 30},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := strings.Repeat("a", tt.size)
+			var buf []byte
+			switch {
+			case tt.size < 29:
+				buf = append(buf, 0x40|byte(tt.size))
+			case tt.size == 29:
+				buf = append(buf, 0x5D, 0x00) // 29 + 0
+			default:
+				buf = append(buf, 0x5D, byte(tt.size-29))
+			}
+			buf = append(buf, key...)
+
+			d := NewDataDecoder(buf)
+			got, newOffset, err := d.decodeKey(0)
+			require.NoError(t, err)
+			require.Equal(t, key, string(got))
+			require.Equal(t, uint(len(buf)), newOffset)
+		})
+	}
+
+	t.Run("size 28 truncated buffer fails", func(t *testing.T) {
+		// Fast path: ctrl says size=28, but buffer holds only the ctrl byte.
+		d := NewDataDecoder([]byte{0x5C})
+		_, _, err := d.decodeKey(0)
+		require.Error(t, err)
+	})
 }
 
 // TestDecodeKeyFollowsPointer verifies that a pointer control byte at the

--- a/internal/decoder/nested_unmarshaler_test.go
+++ b/internal/decoder/nested_unmarshaler_test.go
@@ -300,3 +300,333 @@ func TestCustomUnmarshalerWithIterator(t *testing.T) {
 	assert.Equal(t, "-74.0", result.Location.Values["lng"])
 	assert.Equal(t, "US", result.Country)
 }
+
+type testInterfaceUnmarshaler struct {
+	Value  string
+	custom bool
+}
+
+func (u *testInterfaceUnmarshaler) UnmarshalMaxMindDB(d *Decoder) error {
+	u.custom = true
+	value, err := d.ReadString()
+	if err != nil {
+		return err
+	}
+	u.Value = "interface:" + value
+	return nil
+}
+
+func TestPreinitializedInterfaceFieldUsesUnmarshaler(t *testing.T) {
+	type Record struct {
+		Field any `maxminddb:"field"`
+	}
+
+	data := []byte{
+		0xe1,
+		0x45, 'f', 'i', 'e', 'l', 'd',
+		0x44, 't', 'e', 's', 't',
+	}
+
+	inner := &testInterfaceUnmarshaler{}
+	result := Record{Field: inner}
+	d := New(data)
+	require.NoError(t, d.Decode(0, &result))
+	assert.Same(t, inner, result.Field)
+	assert.True(t, inner.custom)
+	assert.Equal(t, "interface:test", inner.Value)
+}
+
+// markedString and friends below are named primitive types implementing
+// UnmarshalMaxMindDB with a transform whose output is distinguishable
+// from the raw decoded value. If the fast path in tryFastDecodeTyped
+// bypasses the unmarshaler, the field decodes to the raw value; if the
+// slow path runs, it decodes to the transformed value.
+
+type markedString string
+
+func (m *markedString) UnmarshalMaxMindDB(d *Decoder) error {
+	s, err := d.ReadString()
+	if err != nil {
+		return err
+	}
+	*m = markedString("X:" + s)
+	return nil
+}
+
+type markedBool bool
+
+func (m *markedBool) UnmarshalMaxMindDB(d *Decoder) error {
+	b, err := d.ReadBool()
+	if err != nil {
+		return err
+	}
+	*m = markedBool(!b)
+	return nil
+}
+
+type markedUint uint
+
+func (m *markedUint) UnmarshalMaxMindDB(d *Decoder) error {
+	n, err := d.ReadUint64()
+	if err != nil {
+		return err
+	}
+	*m = markedUint(n) + 1000
+	return nil
+}
+
+type markedUint16 uint16
+
+func (m *markedUint16) UnmarshalMaxMindDB(d *Decoder) error {
+	n, err := d.ReadUint16()
+	if err != nil {
+		return err
+	}
+	*m = markedUint16(n) + 1000
+	return nil
+}
+
+type markedUint32 uint32
+
+func (m *markedUint32) UnmarshalMaxMindDB(d *Decoder) error {
+	n, err := d.ReadUint32()
+	if err != nil {
+		return err
+	}
+	*m = markedUint32(n) + 1000
+	return nil
+}
+
+type markedUint64 uint64
+
+func (m *markedUint64) UnmarshalMaxMindDB(d *Decoder) error {
+	n, err := d.ReadUint64()
+	if err != nil {
+		return err
+	}
+	*m = markedUint64(n) + 1000
+	return nil
+}
+
+type markedFloat64 float64
+
+func (m *markedFloat64) UnmarshalMaxMindDB(d *Decoder) error {
+	f, err := d.ReadFloat64()
+	if err != nil {
+		return err
+	}
+	*m = markedFloat64(-f)
+	return nil
+}
+
+// TestFastPathPreservesUnmarshalerForNamedTypes guards every fast-path
+// kind against a regression where decodeStruct's isFastType
+// short-circuit runs before the checkUnmarshaler branch and silently
+// bypasses UnmarshalMaxMindDB on named primitive fields. The hazard
+// applies to String, Bool, Uint, Uint16/32/64, and Float64 — and to
+// pointers to each (isFastDecodeType recurses through Pointer).
+func TestFastPathPreservesUnmarshalerForNamedTypes(t *testing.T) {
+	mapPrefix := []byte{0xe1, 0x41, 'v'} // map size 1, key "v"
+	wrap := func(value ...byte) []byte {
+		return append(append([]byte{}, mapPrefix...), value...)
+	}
+
+	cases := []struct {
+		name       string
+		data       []byte
+		runValue   func(t *testing.T, data []byte)
+		runPointer func(t *testing.T, data []byte)
+	}{
+		{
+			name: "string",
+			data: wrap(0x43, 'f', 'o', 'o'),
+			runValue: func(t *testing.T, data []byte) {
+				type record struct {
+					V markedString `maxminddb:"v"`
+				}
+				var r record
+				d := New(data)
+				require.NoError(t, d.Decode(0, &r))
+				require.Equal(t, markedString("X:foo"), r.V)
+			},
+			runPointer: func(t *testing.T, data []byte) {
+				type record struct {
+					V *markedString `maxminddb:"v"`
+				}
+				var r record
+				d := New(data)
+				require.NoError(t, d.Decode(0, &r))
+				require.NotNil(t, r.V)
+				require.Equal(t, markedString("X:foo"), *r.V)
+			},
+		},
+		{
+			name: "bool",
+			// extended (high=0), size=1; kind byte 7 means Kind(7+7)=14=Bool; size=1 -> true
+			data: wrap(0x01, 0x07),
+			runValue: func(t *testing.T, data []byte) {
+				type record struct {
+					V markedBool `maxminddb:"v"`
+				}
+				var r record
+				d := New(data)
+				require.NoError(t, d.Decode(0, &r))
+				require.Equal(t, markedBool(false), r.V)
+			},
+			runPointer: func(t *testing.T, data []byte) {
+				type record struct {
+					V *markedBool `maxminddb:"v"`
+				}
+				var r record
+				d := New(data)
+				require.NoError(t, d.Decode(0, &r))
+				require.NotNil(t, r.V)
+				require.Equal(t, markedBool(false), *r.V)
+			},
+		},
+		{
+			name: "uint",
+			// extended, size=1; kind byte 2 -> Kind(9)=Uint64; value 42
+			data: wrap(0x01, 0x02, 0x2a),
+			runValue: func(t *testing.T, data []byte) {
+				type record struct {
+					V markedUint `maxminddb:"v"`
+				}
+				var r record
+				d := New(data)
+				require.NoError(t, d.Decode(0, &r))
+				require.Equal(t, markedUint(1042), r.V)
+			},
+			runPointer: func(t *testing.T, data []byte) {
+				type record struct {
+					V *markedUint `maxminddb:"v"`
+				}
+				var r record
+				d := New(data)
+				require.NoError(t, d.Decode(0, &r))
+				require.NotNil(t, r.V)
+				require.Equal(t, markedUint(1042), *r.V)
+			},
+		},
+		{
+			name: "uint16",
+			data: wrap(0xa1, 0x2a), // KindUint16, size=1, value 42
+			runValue: func(t *testing.T, data []byte) {
+				type record struct {
+					V markedUint16 `maxminddb:"v"`
+				}
+				var r record
+				d := New(data)
+				require.NoError(t, d.Decode(0, &r))
+				require.Equal(t, markedUint16(1042), r.V)
+			},
+			runPointer: func(t *testing.T, data []byte) {
+				type record struct {
+					V *markedUint16 `maxminddb:"v"`
+				}
+				var r record
+				d := New(data)
+				require.NoError(t, d.Decode(0, &r))
+				require.NotNil(t, r.V)
+				require.Equal(t, markedUint16(1042), *r.V)
+			},
+		},
+		{
+			name: "uint32",
+			data: wrap(0xc1, 0x2a), // KindUint32, size=1, value 42
+			runValue: func(t *testing.T, data []byte) {
+				type record struct {
+					V markedUint32 `maxminddb:"v"`
+				}
+				var r record
+				d := New(data)
+				require.NoError(t, d.Decode(0, &r))
+				require.Equal(t, markedUint32(1042), r.V)
+			},
+			runPointer: func(t *testing.T, data []byte) {
+				type record struct {
+					V *markedUint32 `maxminddb:"v"`
+				}
+				var r record
+				d := New(data)
+				require.NoError(t, d.Decode(0, &r))
+				require.NotNil(t, r.V)
+				require.Equal(t, markedUint32(1042), *r.V)
+			},
+		},
+		{
+			name: "uint64",
+			data: wrap(0x01, 0x02, 0x2a), // extended Uint64, size=1, value 42
+			runValue: func(t *testing.T, data []byte) {
+				type record struct {
+					V markedUint64 `maxminddb:"v"`
+				}
+				var r record
+				d := New(data)
+				require.NoError(t, d.Decode(0, &r))
+				require.Equal(t, markedUint64(1042), r.V)
+			},
+			runPointer: func(t *testing.T, data []byte) {
+				type record struct {
+					V *markedUint64 `maxminddb:"v"`
+				}
+				var r record
+				d := New(data)
+				require.NoError(t, d.Decode(0, &r))
+				require.NotNil(t, r.V)
+				require.Equal(t, markedUint64(1042), *r.V)
+			},
+		},
+		{
+			name: "float64",
+			// KindFloat64 (high=3), size=8; IEEE 754 of 3.14159265359
+			data: wrap(0x68, 0x40, 0x09, 0x21, 0xfb, 0x54, 0x44, 0x2e, 0xea),
+			runValue: func(t *testing.T, data []byte) {
+				type record struct {
+					V markedFloat64 `maxminddb:"v"`
+				}
+				var r record
+				d := New(data)
+				require.NoError(t, d.Decode(0, &r))
+				require.InDelta(t, -3.14159265359, float64(r.V), 1e-9)
+			},
+			runPointer: func(t *testing.T, data []byte) {
+				type record struct {
+					V *markedFloat64 `maxminddb:"v"`
+				}
+				var r record
+				d := New(data)
+				require.NoError(t, d.Decode(0, &r))
+				require.NotNil(t, r.V)
+				require.InDelta(t, -3.14159265359, float64(*r.V), 1e-9)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name+"/value", func(t *testing.T) { tc.runValue(t, tc.data) })
+		t.Run(tc.name+"/pointer", func(t *testing.T) { tc.runPointer(t, tc.data) })
+	}
+}
+
+func TestPreinitializedPointerToInterfaceFieldUsesUnmarshaler(t *testing.T) {
+	type Record struct {
+		Field *any `maxminddb:"field"`
+	}
+
+	data := []byte{
+		0xe1,
+		0x45, 'f', 'i', 'e', 'l', 'd',
+		0x44, 't', 'e', 's', 't',
+	}
+
+	inner := &testInterfaceUnmarshaler{}
+	holder := any(inner)
+	result := Record{Field: &holder}
+	d := New(data)
+	require.NoError(t, d.Decode(0, &result))
+	require.NotNil(t, result.Field)
+	assert.Same(t, inner, (*result.Field).(*testInterfaceUnmarshaler))
+	assert.True(t, inner.custom)
+	assert.Equal(t, "interface:test", inner.Value)
+}

--- a/internal/decoder/reflection.go
+++ b/internal/decoder/reflection.go
@@ -773,12 +773,26 @@ func (d *ReflectionDecoder) decodeSlice(
 	result addressableValue,
 	depth int,
 ) (uint, error) {
-	result.Set(reflect.MakeSlice(result.Type(), int(size), int(size)))
+	sliceLen := int(size)
+	if result.IsNil() || result.Cap() < sliceLen {
+		result.Set(reflect.MakeSlice(result.Type(), sliceLen, sliceLen))
+	} else {
+		// Reuse the caller's backing array. Two clears are needed: the first
+		// zeroes [0:sliceLen] so element fields not present in the new data
+		// (e.g., omitted struct keys) don't carry forward; the second zeroes
+		// (sliceLen:oldLen] so the now-hidden tail drops any pointer-like
+		// references it held, letting the GC reclaim them.
+		oldLen := result.Len()
+		result.SetLen(sliceLen)
+		result.Clear()
+		if oldLen > sliceLen {
+			result.Slice(sliceLen, oldLen).Clear()
+		}
+	}
+
 	for i := range size {
 		var err error
-		// Use slice element directly to avoid allocation
-		elemVal := result.Index(int(i))
-		elemValue := addressableValue{Value: elemVal, forcedAddr: false}
+		elemValue := addressableValue{Value: result.Index(int(i))}
 		offset, err = d.decodeValue(offset, elemValue, depth)
 		if err != nil {
 			return 0, d.wrapErrorWithSliceIndex(err, int(i))

--- a/internal/decoder/reflection.go
+++ b/internal/decoder/reflection.go
@@ -866,23 +866,26 @@ func (d *ReflectionDecoder) decodeStruct(
 			continue
 		}
 
-		// Fast path for common simple field types
-		if len(fieldInfo.index) == 0 && fieldInfo.isFastType {
-			// Try fast decode path for pre-identified simple types
-			if fastOffset, ok := d.tryFastDecodeTyped(offset, fieldValue, fieldInfo.fieldType); ok {
-				offset = fastOffset
-				continue
+		// Dispatch on the precomputed strategy. The fast-path case has a
+		// runtime guard for embedded fields (len(index) > 0): the
+		// fast-path decoders bypass embedded-pointer initialization,
+		// which is the caller's responsibility on the slow path.
+		switch fieldInfo.dispatch {
+		case dispatchFast:
+			if len(fieldInfo.index) == 0 {
+				if fastOffset, ok := d.tryFastDecodeTyped(
+					offset,
+					fieldValue,
+					fieldInfo.fieldType,
+				); ok {
+					offset = fastOffset
+					continue
+				}
 			}
-		}
-
-		// Interface fields take the checking path because the concrete type
-		// behind the interface isn't known at struct-cache build time, so
-		// mayImplementUnmarshaler can't be precomputed for them.
-		if fieldInfo.mayImplementUnmarshaler ||
-			fieldValue.Kind() == reflect.Interface ||
-			unwrapPtrType(fieldInfo.fieldType).Kind() == reflect.Interface {
+			offset, err = d.decodeValueSkipUnmarshaler(offset, fieldValue, depth)
+		case dispatchUnmarshaler:
 			offset, err = d.decodeValue(offset, fieldValue, depth)
-		} else {
+		default: // dispatchPlain
 			offset, err = d.decodeValueSkipUnmarshaler(offset, fieldValue, depth)
 		}
 		if err != nil {
@@ -892,15 +895,38 @@ func (d *ReflectionDecoder) decodeStruct(
 	return offset, nil
 }
 
+// fieldDispatch encodes the decode strategy for a struct field, computed
+// once at struct-cache build time. Encoding the three-way choice as a
+// single enum (rather than two non-orthogonal booleans) makes the
+// illegal combination "fast path AND Unmarshaler" unrepresentable —
+// previously enforced only by an `&&` in makeStructFields.
+type fieldDispatch uint8
+
+const (
+	// dispatchFast: field type is one of the primitive Go kinds the
+	// fast path supports (string/bool/uint*/float64 or pointer to such)
+	// and its unwrapped type does not implement Unmarshaler. The fast
+	// path is attempted; on type-num mismatch it falls back to
+	// decodeValueSkipUnmarshaler (which is sound: the field type cannot
+	// implement Unmarshaler by construction).
+	dispatchFast fieldDispatch = iota
+	// dispatchUnmarshaler: field's unwrapped type is an interface or
+	// implements Unmarshaler via its pointer receiver. Goes through
+	// decodeValue, which performs the type assertion.
+	dispatchUnmarshaler
+	// dispatchPlain: everything else (structs, slices, maps, named
+	// types without Unmarshaler). Uses decodeValueSkipUnmarshaler.
+	dispatchPlain
+)
+
 type fieldInfo struct {
-	fieldType               reflect.Type
-	name                    string
-	index                   []int
-	index0                  int
-	depth                   int
-	hasTag                  bool
-	isFastType              bool
-	mayImplementUnmarshaler bool
+	fieldType reflect.Type
+	name      string
+	index     []int
+	index0    int
+	depth     int
+	hasTag    bool
+	dispatch  fieldDispatch
 }
 
 type fieldsType struct {
@@ -1055,24 +1081,31 @@ func makeStructFields(rootType reflect.Type) *fieldsType {
 				continue
 			}
 
-			// Add field to collection with optimization hints. isFastType
-			// is gated on !checkUnmarshaler so a named primitive type
-			// whose pointer receiver implements UnmarshalMaxMindDB takes
-			// the slow path (which dispatches to the custom unmarshaler)
-			// rather than the inline fast path (which would assign the
-			// raw decoded value and bypass the unmarshaler). The order of
-			// the && lets Go short-circuit isFastDecodeType when the
-			// unmarshaler check already disqualifies the fast path.
+			// Resolve dispatch strategy once per field. Unmarshaler
+			// possibility takes precedence over fast-path eligibility so
+			// a named primitive type whose pointer receiver implements
+			// UnmarshalMaxMindDB always takes the slow path. The case
+			// order matches that precedence; the switch is exhaustive
+			// because dispatchPlain is the default fallback.
 			fieldType := field.Type
-			mayUnmarshal := mayImplementUnmarshaler(unwrapPtrType(fieldType))
+			unwrappedFieldType := unwrapPtrType(fieldType)
+			var dispatch fieldDispatch
+			switch {
+			case mayImplementUnmarshaler(unwrappedFieldType) ||
+				unwrappedFieldType.Kind() == reflect.Interface:
+				dispatch = dispatchUnmarshaler
+			case isFastDecodeType(fieldType):
+				dispatch = dispatchFast
+			default:
+				dispatch = dispatchPlain
+			}
 			allFields = append(allFields, fieldInfo{
-				index:                   fieldIndex, // Will be reindexed later for optimization
-				name:                    fieldName,
-				hasTag:                  hasTag,
-				depth:                   entry.depth,
-				fieldType:               fieldType,
-				isFastType:              !mayUnmarshal && isFastDecodeType(fieldType),
-				mayImplementUnmarshaler: mayUnmarshal,
+				index:     fieldIndex, // Will be reindexed later for optimization
+				name:      fieldName,
+				hasTag:    hasTag,
+				depth:     entry.depth,
+				fieldType: fieldType,
+				dispatch:  dispatch,
 			})
 		}
 	}
@@ -1278,7 +1311,7 @@ func (av addressableValue) indirect(mayAlloc bool) addressableValue {
 // tryFastDecodeTyped returns (newOffset, true) on success and (0, false)
 // on any failure: a malformed buffer, a DB-type/Go-kind mismatch, or an
 // inner decode error. Error surfacing relies on the caller (decodeStruct
-// at the isFastType branch) re-decoding from the same offset via the
+// in the dispatchFast case) re-decoding from the same offset via the
 // slow path, which re-encounters the underlying error and propagates it
 // with proper context. The fast path itself never logs or wraps.
 func (d *ReflectionDecoder) tryFastDecodeTyped(

--- a/internal/decoder/reflection.go
+++ b/internal/decoder/reflection.go
@@ -1247,6 +1247,7 @@ func isFastDecodeType(t reflect.Type) bool {
 	switch t.Kind() {
 	case reflect.String,
 		reflect.Bool,
+		reflect.Uint,
 		reflect.Uint16,
 		reflect.Uint32,
 		reflect.Uint64,
@@ -1314,6 +1315,8 @@ func (av addressableValue) indirect(mayAlloc bool) addressableValue {
 // in the dispatchFast case) re-decoding from the same offset via the
 // slow path, which re-encounters the underlying error and propagates it
 // with proper context. The fast path itself never logs or wraps.
+//
+//nolint:gocyclo // fairly readable and this is optimized code.
 func (d *ReflectionDecoder) tryFastDecodeTyped(
 	offset uint,
 	result addressableValue,
@@ -1333,6 +1336,30 @@ func (d *ReflectionDecoder) tryFastDecodeTyped(
 				return 0, false
 			}
 			result.SetString(value)
+			return finalOffset, true
+		}
+	case reflect.Uint:
+		switch typeNum {
+		case KindUint16:
+			value, finalOffset, err := d.decodeUint16(size, newOffset)
+			if err != nil {
+				return 0, false
+			}
+			result.SetUint(uint64(value))
+			return finalOffset, true
+		case KindUint32:
+			value, finalOffset, err := d.decodeUint32(size, newOffset)
+			if err != nil {
+				return 0, false
+			}
+			result.SetUint(uint64(value))
+			return finalOffset, true
+		case KindUint64:
+			value, finalOffset, err := d.decodeUint64(size, newOffset)
+			if err != nil || uint64(uint(value)) != value {
+				return 0, false
+			}
+			result.SetUint(value)
 			return finalOffset, true
 		}
 	case reflect.Uint32:

--- a/internal/decoder/reflection.go
+++ b/internal/decoder/reflection.go
@@ -66,7 +66,7 @@ func (d *ReflectionDecoder) Decode(offset uint, v any) error {
 	}
 
 	rv := reflect.ValueOf(v)
-	if rv.Kind() != reflect.Ptr || rv.IsNil() {
+	if rv.Kind() != reflect.Pointer || rv.IsNil() {
 		return errors.New("result param must be a pointer")
 	}
 
@@ -98,7 +98,7 @@ func (d *ReflectionDecoder) DecodePath(
 	v any,
 ) error {
 	result := reflect.ValueOf(v)
-	if result.Kind() != reflect.Ptr || result.IsNil() {
+	if result.Kind() != reflect.Pointer || result.IsNil() {
 		return errors.New("result param must be a pointer")
 	}
 
@@ -297,13 +297,13 @@ func (d *ReflectionDecoder) decodeValueImpl(
 		// usefully addressable.
 		if result.Kind() == reflect.Interface && !result.IsNil() {
 			e := result.Elem()
-			if e.Kind() == reflect.Ptr && !e.IsNil() {
+			if e.Kind() == reflect.Pointer && !e.IsNil() {
 				result = addressableValue{e, result.forcedAddr}
 				continue
 			}
 		}
 
-		if result.Kind() != reflect.Ptr {
+		if result.Kind() != reflect.Pointer {
 			break
 		}
 
@@ -966,7 +966,7 @@ func getEmbeddedStructType(fieldType reflect.Type) reflect.Type {
 	if fieldType.Kind() == reflect.Struct {
 		return fieldType
 	}
-	if fieldType.Kind() == reflect.Ptr && fieldType.Elem().Kind() == reflect.Struct {
+	if fieldType.Kind() == reflect.Pointer && fieldType.Elem().Kind() == reflect.Struct {
 		return fieldType.Elem()
 	}
 	return nil
@@ -1253,7 +1253,7 @@ func isFastDecodeType(t reflect.Type) bool {
 		reflect.Uint64,
 		reflect.Float64:
 		return true
-	case reflect.Ptr:
+	case reflect.Pointer:
 		return isFastDecodeType(t.Elem())
 	default:
 		return false
@@ -1297,7 +1297,7 @@ func (av addressableValue) fieldByIndex(
 
 // indirect handles pointer dereferencing and initialization.
 func (av addressableValue) indirect(mayAlloc bool) addressableValue {
-	if av.Kind() == reflect.Ptr {
+	if av.Kind() == reflect.Pointer {
 		if av.IsNil() {
 			if !mayAlloc || !av.CanSet() {
 				return addressableValue{} // Return invalid value
@@ -1407,7 +1407,7 @@ func (d *ReflectionDecoder) tryFastDecodeTyped(
 			result.SetFloat(value)
 			return finalOffset, true
 		}
-	case reflect.Ptr:
+	case reflect.Pointer:
 		// Handle pointer to fast types
 		if result.IsNil() {
 			elem := reflect.New(expectedType.Elem()).Elem()

--- a/internal/decoder/reflection.go
+++ b/internal/decoder/reflection.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/big"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"unicode/utf8"
@@ -233,18 +234,21 @@ func wrapErrorWithPath(err error, prepend func(*mmdberrors.PathBuilder)) error {
 }
 
 func (d *ReflectionDecoder) decode(offset uint, result reflect.Value, depth int) (uint, error) {
-	// Convert to addressableValue and delegate to internal method
-	// Use fast path for already addressable values to avoid allocation
-	if result.CanAddr() {
-		av := addressableValue{Value: result, forcedAddr: false}
-		return d.decodeValue(offset, av, depth)
+	// Skip makeAddressable's boxing copy whenever result is already addressable.
+	// The common Decode(&v) entry passes a non-addressable pointer, but its
+	// Elem() is addressable, so we can decode through it directly. Callers that
+	// already supplied an addressable Value (e.g., a struct field) take the
+	// CanAddr branch. Only non-addressable, non-pointer values need
+	// makeAddressable, which allocates.
+	if result.Kind() == reflect.Pointer && !result.IsNil() {
+		return d.decodeValue(offset, addressableValue{Value: result.Elem()}, depth)
 	}
-	av := makeAddressable(result)
-	return d.decodeValue(offset, av, depth)
+	if result.CanAddr() {
+		return d.decodeValue(offset, addressableValue{Value: result}, depth)
+	}
+	return d.decodeValue(offset, makeAddressable(result), depth)
 }
 
-// decodeValue is the internal decode method that works with addressableValue
-// for consistent optimization throughout the decoder.
 func (d *ReflectionDecoder) decodeValue(
 	offset uint,
 	result addressableValue,
@@ -262,8 +266,8 @@ func (d *ReflectionDecoder) decodeValue(
 			return
 		}
 
-		for i := len(allocatedPointers) - 1; i >= 0; i-- {
-			allocatedPointers[i].SetZero()
+		for _, pointer := range slices.Backward(allocatedPointers) {
+			pointer.SetZero()
 		}
 	}()
 
@@ -515,7 +519,7 @@ func (d *ReflectionDecoder) unmarshalMap(
 		if result.NumMethod() == 0 {
 			// Create map directly without makeAddressable wrapper
 			mapVal := reflect.ValueOf(make(map[string]any, size))
-			rv := addressableValue{Value: mapVal, forcedAddr: false}
+			rv := addressableValue{Value: mapVal}
 			newOffset, err := d.decodeMap(size, offset, rv, depth)
 			result.Set(rv.Value)
 			return newOffset, err
@@ -566,7 +570,7 @@ func (d *ReflectionDecoder) unmarshalSlice(
 			a := []any{}
 			// Create slice directly without makeAddressable wrapper
 			sliceVal := reflect.ValueOf(&a).Elem()
-			rv := addressableValue{Value: sliceVal, forcedAddr: false}
+			rv := addressableValue{Value: sliceVal}
 			newOffset, err := d.decodeSlice(size, offset, rv, depth)
 			result.Set(rv.Value)
 			return newOffset, err
@@ -734,12 +738,12 @@ func (d *ReflectionDecoder) decodeMap(
 
 	// Pre-allocated values for efficient reuse
 	keyVal := reflect.New(mapType.Key()).Elem()
-	keyValue := addressableValue{Value: keyVal, forcedAddr: false}
+	keyValue := addressableValue{Value: keyVal}
 	elemType := mapType.Elem()
 	var elemValue addressableValue
 	// Pre-allocate element value to reduce allocations
 	elemVal := reflect.New(elemType).Elem()
-	elemValue = addressableValue{Value: elemVal, forcedAddr: false}
+	elemValue = addressableValue{Value: elemVal}
 	for range size {
 		var err error
 
@@ -1133,7 +1137,7 @@ type addressableValue struct {
 // If the value is not addressable, it wraps it to make it addressable.
 func newAddressableValue(v reflect.Value) addressableValue {
 	if v.CanAddr() {
-		return addressableValue{Value: v, forcedAddr: false}
+		return addressableValue{Value: v}
 	}
 	// Make non-addressable values addressable by boxing them
 	addressable := reflect.New(v.Type()).Elem()
@@ -1146,7 +1150,7 @@ func newAddressableValue(v reflect.Value) addressableValue {
 func makeAddressable(v reflect.Value) addressableValue {
 	// Fast path for already addressable values
 	if v.CanAddr() {
-		return addressableValue{Value: v, forcedAddr: false}
+		return addressableValue{Value: v}
 	}
 	return newAddressableValue(v)
 }
@@ -1162,7 +1166,6 @@ func isFastDecodeType(t reflect.Type) bool {
 		reflect.Float64:
 		return true
 	case reflect.Ptr:
-		// Pointer to fast types are also fast
 		return isFastDecodeType(t.Elem())
 	default:
 		return false
@@ -1202,12 +1205,17 @@ func (av addressableValue) indirect(mayAlloc bool) addressableValue {
 			}
 			av.Set(reflect.New(av.Type().Elem()))
 		}
-		av = addressableValue{av.Elem(), false}
+		av = addressableValue{Value: av.Elem()}
 	}
 	return av
 }
 
-// tryFastDecodeTyped attempts to decode using pre-computed type information.
+// tryFastDecodeTyped returns (newOffset, true) on success and (0, false)
+// on any failure: a malformed buffer, a DB-type/Go-kind mismatch, or an
+// inner decode error. Error surfacing relies on the caller (decodeStruct
+// at the isFastType branch) re-decoding from the same offset via the
+// slow path, which re-encounters the underlying error and propagates it
+// with proper context. The fast path itself never logs or wraps.
 func (d *ReflectionDecoder) tryFastDecodeTyped(
 	offset uint,
 	result addressableValue,
@@ -1280,7 +1288,7 @@ func (d *ReflectionDecoder) tryFastDecodeTyped(
 			elem := reflect.New(expectedType.Elem()).Elem()
 			finalOffset, ok := d.tryFastDecodeTyped(
 				offset,
-				addressableValue{elem, false},
+				addressableValue{Value: elem},
 				expectedType.Elem(),
 			)
 			if !ok {
@@ -1291,7 +1299,7 @@ func (d *ReflectionDecoder) tryFastDecodeTyped(
 		}
 		return d.tryFastDecodeTyped(
 			offset,
-			addressableValue{result.Elem(), false},
+			addressableValue{Value: result.Elem()},
 			expectedType.Elem(),
 		)
 	default:

--- a/internal/decoder/reflection.go
+++ b/internal/decoder/reflection.go
@@ -254,6 +254,26 @@ func (d *ReflectionDecoder) decodeValue(
 	result addressableValue,
 	depth int,
 ) (newOffset uint, retErr error) {
+	return d.decodeValueImpl(offset, result, depth, true)
+}
+
+// decodeValueSkipUnmarshaler is the struct-field fast path: when the
+// destination type was precomputed to not implement Unmarshaler, we skip
+// the reflective type-assert that decodeValue would otherwise perform.
+func (d *ReflectionDecoder) decodeValueSkipUnmarshaler(
+	offset uint,
+	result addressableValue,
+	depth int,
+) (newOffset uint, retErr error) {
+	return d.decodeValueImpl(offset, result, depth, false)
+}
+
+func (d *ReflectionDecoder) decodeValueImpl(
+	offset uint,
+	result addressableValue,
+	depth int,
+	checkUnmarshaler bool,
+) (newOffset uint, retErr error) {
 	if depth > maximumDataStructureDepth {
 		return 0, mmdberrors.NewInvalidDatabaseError(
 			"exceeded maximum data structure depth; database is likely corrupt",
@@ -298,9 +318,11 @@ func (d *ReflectionDecoder) decodeValue(
 		} // dereferenced pointer is always addressable
 	}
 
-	// Skip the reflective type assertion when the destination type cannot
-	// implement Unmarshaler. This is the common case in normal struct decoding.
-	if result.CanAddr() && mayImplementUnmarshaler(result.Type()) {
+	// Try Unmarshaler dispatch only when the type might actually implement
+	// the interface. Struct decoding passes checkUnmarshaler=false when the
+	// per-field precomputation already established the destination cannot
+	// match, avoiding the reflective type assertion entirely.
+	if checkUnmarshaler && result.CanAddr() && mayImplementUnmarshaler(result.Type()) {
 		if unmarshaler, ok := tryTypeAssert(result.Addr()); ok {
 			decoder := NewDecoder(d.DataDecoder, offset)
 			if err := unmarshaler.UnmarshalMaxMindDB(decoder); err != nil {
@@ -853,7 +875,16 @@ func (d *ReflectionDecoder) decodeStruct(
 			}
 		}
 
-		offset, err = d.decodeValue(offset, fieldValue, depth)
+		// Interface fields take the checking path because the concrete type
+		// behind the interface isn't known at struct-cache build time, so
+		// mayImplementUnmarshaler can't be precomputed for them.
+		if fieldInfo.mayImplementUnmarshaler ||
+			fieldValue.Kind() == reflect.Interface ||
+			unwrapPtrType(fieldInfo.fieldType).Kind() == reflect.Interface {
+			offset, err = d.decodeValue(offset, fieldValue, depth)
+		} else {
+			offset, err = d.decodeValueSkipUnmarshaler(offset, fieldValue, depth)
+		}
 		if err != nil {
 			return 0, d.wrapErrorWithMapKey(err, string(key))
 		}
@@ -862,13 +893,14 @@ func (d *ReflectionDecoder) decodeStruct(
 }
 
 type fieldInfo struct {
-	fieldType  reflect.Type
-	name       string
-	index      []int
-	index0     int
-	depth      int
-	hasTag     bool
-	isFastType bool
+	fieldType               reflect.Type
+	name                    string
+	index                   []int
+	index0                  int
+	depth                   int
+	hasTag                  bool
+	isFastType              bool
+	mayImplementUnmarshaler bool
 }
 
 type fieldsType struct {
@@ -1023,16 +1055,24 @@ func makeStructFields(rootType reflect.Type) *fieldsType {
 				continue
 			}
 
-			// Add field to collection with optimization hints
+			// Add field to collection with optimization hints. isFastType
+			// is gated on !checkUnmarshaler so a named primitive type
+			// whose pointer receiver implements UnmarshalMaxMindDB takes
+			// the slow path (which dispatches to the custom unmarshaler)
+			// rather than the inline fast path (which would assign the
+			// raw decoded value and bypass the unmarshaler). The order of
+			// the && lets Go short-circuit isFastDecodeType when the
+			// unmarshaler check already disqualifies the fast path.
 			fieldType := field.Type
-			isFast := isFastDecodeType(fieldType)
+			mayUnmarshal := mayImplementUnmarshaler(unwrapPtrType(fieldType))
 			allFields = append(allFields, fieldInfo{
-				index:      fieldIndex, // Will be reindexed later for optimization
-				name:       fieldName,
-				hasTag:     hasTag,
-				depth:      entry.depth,
-				fieldType:  fieldType,
-				isFastType: isFast,
+				index:                   fieldIndex, // Will be reindexed later for optimization
+				name:                    fieldName,
+				hasTag:                  hasTag,
+				depth:                   entry.depth,
+				fieldType:               fieldType,
+				isFastType:              !mayUnmarshal && isFastDecodeType(fieldType),
+				mayImplementUnmarshaler: mayUnmarshal,
 			})
 		}
 	}
@@ -1184,6 +1224,17 @@ func isFastDecodeType(t reflect.Type) bool {
 	default:
 		return false
 	}
+}
+
+// unwrapPtrType strips all pointer indirection from t and returns the
+// underlying element type. Used to find the addressable receiver type that
+// mayImplementUnmarshaler should check, since decoding allocates and
+// dereferences as many *T layers as the field declares.
+func unwrapPtrType(t reflect.Type) reflect.Type {
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+	return t
 }
 
 // fieldByIndex efficiently accesses a field by its index path,

--- a/internal/decoder/reflection_test.go
+++ b/internal/decoder/reflection_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -132,6 +133,208 @@ func TestSlice(t *testing.T) {
 		"020443466f6f43e4baba": []any{"Foo", "人"},
 	}
 	validateDecoding(t, slice)
+}
+
+func TestDecodeSliceClearsReusedElements(t *testing.T) {
+	type item struct {
+		Name  string `maxminddb:"name"`
+		Extra string `maxminddb:"extra"`
+	}
+	type record struct {
+		Items []item `maxminddb:"items"`
+	}
+
+	firstData := []byte{
+		0xe1,
+		0x45, 'i', 't', 'e', 'm', 's',
+		0x01, 0x04,
+		0xe2,
+		0x44, 'n', 'a', 'm', 'e',
+		0x43, 'o', 'l', 'd',
+		0x45, 'e', 'x', 't', 'r', 'a',
+		0x45, 's', 't', 'a', 'l', 'e',
+	}
+	secondData := []byte{
+		0xe1,
+		0x45, 'i', 't', 'e', 'm', 's',
+		0x01, 0x04,
+		0xe1,
+		0x44, 'n', 'a', 'm', 'e',
+		0x43, 'n', 'e', 'w',
+	}
+
+	var result record
+	firstDecoder := New(firstData)
+	require.NoError(t, firstDecoder.Decode(0, &result))
+	require.Equal(t, []item{{Name: "old", Extra: "stale"}}, result.Items)
+
+	secondDecoder := New(secondData)
+	require.NoError(t, secondDecoder.Decode(0, &result))
+	require.Equal(t, []item{{Name: "new"}}, result.Items)
+}
+
+// TestDecodeSliceClearsTailReferences exercises the second Clear in
+// decodeSlice (the tail clear when the new slice is shorter than the
+// previous one). When the element type holds reference fields like maps,
+// failing to clear the tail would leak those references via the reused
+// backing array, defeating the GC.
+func TestDecodeSliceClearsTailReferences(t *testing.T) {
+	type item struct {
+		Name string            `maxminddb:"name"`
+		Tags map[string]string `maxminddb:"tags"`
+	}
+	type record struct {
+		Items []item `maxminddb:"items"`
+	}
+
+	// Two elements, each carrying a tags map.
+	firstData := []byte{
+		0xe1,
+		0x45, 'i', 't', 'e', 'm', 's',
+		0x02, 0x04,
+		0xe2,
+		0x44, 'n', 'a', 'm', 'e',
+		0x43, 'o', 'n', 'e',
+		0x44, 't', 'a', 'g', 's',
+		0xe1,
+		0x41, 'a', 0x41, 'b',
+		0xe2,
+		0x44, 'n', 'a', 'm', 'e',
+		0x43, 't', 'w', 'o',
+		0x44, 't', 'a', 'g', 's',
+		0xe1,
+		0x41, 'c', 0x41, 'd',
+	}
+	// One element, no tags.
+	secondData := []byte{
+		0xe1,
+		0x45, 'i', 't', 'e', 'm', 's',
+		0x01, 0x04,
+		0xe1,
+		0x44, 'n', 'a', 'm', 'e',
+		0x43, 'n', 'e', 'w',
+	}
+
+	var result record
+	firstDecoder := New(firstData)
+	require.NoError(t, firstDecoder.Decode(0, &result))
+	require.Len(t, result.Items, 2)
+	require.Equal(t, map[string]string{"a": "b"}, result.Items[0].Tags)
+	require.Equal(t, map[string]string{"c": "d"}, result.Items[1].Tags)
+
+	capBefore := cap(result.Items)
+	require.GreaterOrEqual(t, capBefore, 2,
+		"setup requires cap >= 2 so the second decode reuses the backing array")
+
+	secondDecoder := New(secondData)
+	require.NoError(t, secondDecoder.Decode(0, &result))
+	require.Equal(t, []item{{Name: "new"}}, result.Items)
+
+	full := result.Items[:capBefore]
+	require.Nil(t, full[1].Tags,
+		"hidden tail element's map reference must be cleared (GC)")
+	require.Empty(t, full[1].Name,
+		"hidden tail element's string field must be cleared")
+}
+
+// TestDecodeSliceClearsTailPointers is the pointer-element analog of
+// TestDecodeSliceClearsTailReferences. For []*T the slice element IS the
+// GC root, so the tail-clear path at reflection.go:797-813 is what makes
+// the previously-held element reclaimable. A regression that only cleared
+// [0:sliceLen] would leave the *T at the hidden index pointing at the
+// old object — invisible to a value-element test but caught here.
+func TestDecodeSliceClearsTailPointers(t *testing.T) {
+	type item struct {
+		Name string `maxminddb:"name"`
+	}
+	type record struct {
+		Items []*item `maxminddb:"items"`
+	}
+
+	// Two-element slice: [{Name:"one"}, {Name:"two"}].
+	firstData := []byte{
+		0xe1,
+		0x45, 'i', 't', 'e', 'm', 's',
+		0x02, 0x04,
+		0xe1,
+		0x44, 'n', 'a', 'm', 'e',
+		0x43, 'o', 'n', 'e',
+		0xe1,
+		0x44, 'n', 'a', 'm', 'e',
+		0x43, 't', 'w', 'o',
+	}
+	// One-element slice: [{Name:"new"}].
+	secondData := []byte{
+		0xe1,
+		0x45, 'i', 't', 'e', 'm', 's',
+		0x01, 0x04,
+		0xe1,
+		0x44, 'n', 'a', 'm', 'e',
+		0x43, 'n', 'e', 'w',
+	}
+
+	var result record
+	firstDecoder := New(firstData)
+	require.NoError(t, firstDecoder.Decode(0, &result))
+	require.Len(t, result.Items, 2)
+	require.NotNil(t, result.Items[0])
+	require.NotNil(t, result.Items[1])
+	require.Equal(t, "one", result.Items[0].Name)
+	require.Equal(t, "two", result.Items[1].Name)
+
+	capBefore := cap(result.Items)
+	require.GreaterOrEqual(t, capBefore, 2,
+		"setup requires cap >= 2 so the second decode reuses the backing array")
+
+	secondDecoder := New(secondData)
+	require.NoError(t, secondDecoder.Decode(0, &result))
+	require.Len(t, result.Items, 1)
+	require.NotNil(t, result.Items[0])
+	require.Equal(t, "new", result.Items[0].Name)
+
+	full := result.Items[:capBefore]
+	require.Nil(t, full[1],
+		"hidden tail's *item pointer must be cleared so the previously-held element is GC-eligible")
+}
+
+// TestDecodeSliceReusesBackingArray confirms the perf invariant of the
+// reuse path: a second decode into the same destination must reuse the
+// existing backing array rather than allocate fresh. The sibling
+// TestDecodeSliceClears* tests cover the safety properties of reuse;
+// this test guards against a regression that would silently allocate.
+func TestDecodeSliceReusesBackingArray(t *testing.T) {
+	type record struct {
+		Items []string `maxminddb:"items"`
+	}
+
+	// Map {items: ["aa", "bb", "cc"]}
+	data := []byte{
+		0xe1,
+		0x45, 'i', 't', 'e', 'm', 's',
+		0x03, 0x04,
+		0x42, 'a', 'a',
+		0x42, 'b', 'b',
+		0x42, 'c', 'c',
+	}
+
+	var result record
+	first := New(data)
+	require.NoError(t, first.Decode(0, &result))
+	require.Equal(t, []string{"aa", "bb", "cc"}, result.Items)
+
+	//nolint:gosec // test only
+	firstData := unsafe.SliceData(result.Items)
+	firstCap := cap(result.Items)
+
+	second := New(data)
+	require.NoError(t, second.Decode(0, &result))
+	require.Equal(t, []string{"aa", "bb", "cc"}, result.Items)
+	require.Equal(t, firstCap, cap(result.Items),
+		"capacity should not change on identical second decode")
+	require.Same(t, firstData,
+		//nolint:gosec // test only
+		unsafe.SliceData(result.Items),
+		"second decode must reuse the existing backing array")
 }
 
 var testStrings = makeTestStrings()

--- a/internal/decoder/reflection_test.go
+++ b/internal/decoder/reflection_test.go
@@ -97,6 +97,19 @@ func TestFastDecodePointerFieldDoesNotAllocateOnTypeError(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot unmarshal 1 (uint64) into type string")
 }
 
+func TestDecodeAllocatesTopLevelPointerTarget(t *testing.T) {
+	inputBytes, err := hex.DecodeString("43466f6f")
+	require.NoError(t, err)
+
+	d := New(inputBytes)
+
+	var result *string
+	err = d.Decode(0, &result)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "Foo", *result)
+}
+
 func TestMap(t *testing.T) {
 	maps := map[string]any{
 		"e0":                             map[string]any{},

--- a/internal/decoder/reflection_test.go
+++ b/internal/decoder/reflection_test.go
@@ -83,6 +83,82 @@ func TestNegativeInt32DoesNotDecodeIntoUint(t *testing.T) {
 	assert.Contains(t, err.Error(), "cannot unmarshal -1 (int32) into type uint64")
 }
 
+// TestReflectUintOverflowFallback exercises the platform-width guard in
+// tryFastDecodeTyped's reflect.Uint case: when the DB encodes a uint64
+// value that does not fit in the platform's uint, the fast path must
+// return false so the slow path can decide (succeed on 64-bit; report an
+// overflow error on 32-bit). The fast path silently truncating would
+// regress callers that rely on the slow path's overflow check.
+func TestReflectUintOverflowFallback(t *testing.T) {
+	type record struct {
+		N uint `maxminddb:"n"`
+	}
+
+	// Map {n: 0x1_0000_0000} — 33-bit value, fits in uint64 but overflows uint32.
+	data := []byte{
+		0xe1,      // map size 1
+		0x41, 'n', // key "n"
+		0x05, 0x02, // ctrl: extended, size=5; kind = uint64
+		0x01, 0x00, 0x00, 0x00, 0x00, // big-endian 0x100000000
+	}
+
+	d := New(data)
+	var result record
+	err := d.Decode(0, &result)
+
+	const want uint64 = 1 << 32
+	if unsafe.Sizeof(uint(0)) >= 8 {
+		require.NoError(t, err)
+		require.Equal(t, want, uint64(result.N))
+	} else {
+		require.Error(t, err, "32-bit platforms must surface the overflow")
+		require.ErrorContains(t, err, "cannot unmarshal")
+	}
+}
+
+// TestReflectUintFromMultipleSourceKinds covers the three KindUint*
+// cases that tryFastDecodeTyped's reflect.Uint branch accepts for a
+// plain `uint` field. KindUint64 is already exercised by the overflow
+// test above; this fills in KindUint16 and KindUint32 so a copy-paste
+// error (wrong decoder, shift, or SetUint conversion) in either branch
+// would surface.
+func TestReflectUintFromMultipleSourceKinds(t *testing.T) {
+	type record struct {
+		N uint `maxminddb:"n"`
+	}
+
+	cases := []struct {
+		name string
+		data []byte
+		want uint
+	}{
+		{
+			name: "KindUint16",
+			data: []byte{0xe1, 0x41, 'n', 0xa1, 0x2a}, // map{n: uint16(42)}
+			want: 42,
+		},
+		{
+			name: "KindUint32",
+			data: []byte{0xe1, 0x41, 'n', 0xc1, 0x2a}, // map{n: uint32(42)}
+			want: 42,
+		},
+		{
+			name: "KindUint64",
+			data: []byte{0xe1, 0x41, 'n', 0x01, 0x02, 0x2a}, // map{n: uint64(42)}
+			want: 42,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := New(tc.data)
+			var result record
+			require.NoError(t, d.Decode(0, &result))
+			require.Equal(t, tc.want, result.N)
+		})
+	}
+}
+
 func TestFastDecodePointerFieldDoesNotAllocateOnTypeError(t *testing.T) {
 	inputBytes, err := hex.DecodeString("e14173c101")
 	require.NoError(t, err)

--- a/internal/decoder/string_cache.go
+++ b/internal/decoder/string_cache.go
@@ -1,61 +1,68 @@
 package decoder
 
 import (
-	"sync"
+	"sync/atomic"
 )
 
-// cacheEntry represents a cached string with its offset and dedicated mutex.
 type cacheEntry struct {
 	str    string
 	offset uint
-	mu     sync.RWMutex
 }
 
-// stringCache provides bounded string interning with per-entry mutexes for minimal contention.
-// This achieves thread safety while avoiding the global lock bottleneck.
+// stringCache holds two parallel 4096-slot arrays indexed by offset%4096.
+// entries holds admitted strings; recentMisses records the last missing
+// offset seen at each slot so we can admit only on the second consecutive
+// miss for the same offset (see internAt).
+//
+// The arrays are intentionally separate rather than packed into a single
+// [4096]struct{entry; recentMiss} layout. Packing halves slot density
+// per cache line (4 vs 8) and measurably regresses BenchmarkStringCacheCold
+// by ~8%: cold-sweep workloads benefit more from dense linear scanning of
+// entries than from co-locating each entry with its rarely-touched miss
+// counter.
 type stringCache struct {
-	entries [4096]cacheEntry
+	entries      [4096]atomic.Pointer[cacheEntry]
+	recentMisses [4096]atomic.Uint64
 }
 
-// newStringCache creates a new per-entry mutex-based string cache.
 func newStringCache() *stringCache {
 	return &stringCache{}
 }
 
-// internAt returns a canonical string for the data at the given offset and size.
-// Uses per-entry RWMutex for fine-grained thread safety with minimal contention.
+// internAt returns a string for the data at the given offset and size.
+// Hot offsets are interned and the same backing string is returned on
+// subsequent hits; cold offsets are returned freshly allocated on every
+// call (see the admission rule below).
 func (sc *stringCache) internAt(offset, size uint, data []byte) string {
 	const (
 		minCachedLen = 2   // single byte strings not worth caching
 		maxCachedLen = 100 // reasonable upper bound for geographic strings
 	)
 
-	// Skip caching for very short or very long strings
 	if size < minCachedLen || size > maxCachedLen {
 		return string(data[offset : offset+size])
 	}
 
-	// Use same cache index calculation as original: offset % cacheSize
 	i := offset % uint(len(sc.entries))
 	entry := &sc.entries[i]
 
-	// Fast path: read lock and check
-	entry.mu.RLock()
-	if entry.offset == offset && entry.str != "" {
-		str := entry.str
-		entry.mu.RUnlock()
-		return str
+	if cached := entry.Load(); cached != nil && cached.offset == offset {
+		return cached.str
 	}
-	entry.mu.RUnlock()
 
-	// Cache miss - create new string
 	str := string(data[offset : offset+size])
 
-	// Store with write lock on this specific entry
-	entry.mu.Lock()
-	entry.offset = offset
-	entry.str = str
-	entry.mu.Unlock()
+	// Only admit strings that miss twice in the same slot. This keeps the
+	// lock-free fast path for hot strings while avoiding heap churn for one-offs.
+	// The +1 bias reserves 0 as the "no prior miss" sentinel so the initial
+	// zero state of recentMisses[i] never spuriously matches a real offset of 0.
+	admissionValue := uint64(offset) + 1
+	if sc.recentMisses[i].Swap(admissionValue) == admissionValue {
+		entry.Store(&cacheEntry{
+			str:    str,
+			offset: offset,
+		})
+	}
 
 	return str
 }

--- a/internal/decoder/string_cache_test.go
+++ b/internal/decoder/string_cache_test.go
@@ -1,27 +1,14 @@
 package decoder
 
 import (
+	"sync"
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/require"
 )
 
-func TestStringCacheOffsetZero(t *testing.T) {
-	cache := newStringCache()
-	data := []byte("hello world, this is test data")
-
-	// Test string at offset 0
-	str1 := cache.internAt(0, 5, data)
-	require.Equal(t, "hello", str1)
-
-	// Second call should hit cache and return same interned string
-	str2 := cache.internAt(0, 5, data)
-	require.Equal(t, "hello", str2)
-
-	// Note: Both strings should be identical (cache hit)
-	// We can't easily test if they're the same object without unsafe,
-	// but correctness is verified by the equal values
-}
+var benchmarkStringCacheSink string
 
 func TestStringCacheVariousOffsets(t *testing.T) {
 	cache := newStringCache()
@@ -39,13 +26,136 @@ func TestStringCacheVariousOffsets(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		// First call
-		str1 := cache.internAt(tc.offset, tc.size, data)
-		require.Equal(t, tc.expected, str1)
+		// Repeat 3x: first miss records, second miss admits, third hits.
+		for range 3 {
+			got := cache.internAt(tc.offset, tc.size, data)
+			require.Equal(t, tc.expected, got)
+		}
+	}
+}
 
-		// Second call should hit cache
-		str2 := cache.internAt(tc.offset, tc.size, data)
-		require.Equal(t, tc.expected, str2)
-		// Verify cache hit returns correct value (interning tested via behavior)
+// TestStringCacheTwoMissAdmission verifies the admission policy: the first
+// miss at a given offset records the offset in recentMisses but does not
+// store an entry; the second miss at the same offset admits the entry; the
+// third call hits the cache and returns the admitted string verbatim.
+func TestStringCacheTwoMissAdmission(t *testing.T) {
+	cache := newStringCache()
+	data := []byte("hello world, this is test data")
+
+	str1 := cache.internAt(0, 5, data)
+	require.Equal(t, "hello", str1)
+	require.Nil(t, cache.entries[0].Load(),
+		"first miss must not admit (one-off offsets should not allocate cache slots)")
+
+	str2 := cache.internAt(0, 5, data)
+	require.Equal(t, "hello", str2)
+	entry := cache.entries[0].Load()
+	require.NotNil(t, entry, "second miss at same offset must admit")
+	require.Equal(t, uint(0), entry.offset)
+	require.Equal(t, "hello", entry.str)
+
+	str3 := cache.internAt(0, 5, data)
+	require.Equal(t, "hello", str3)
+	require.Equal(t,
+		//nolint:gosec // test only
+		unsafe.StringData(entry.str), unsafe.StringData(str3),
+		"cache hit must return the admitted string's backing data, not a fresh allocation")
+}
+
+// TestStringCacheNoAdmissionOnSlotCollision verifies that two offsets mapping
+// to the same slot alternately miss without admitting. The Swap rule encodes
+// "saw the same offset twice in a row" — alternation never matches, so the
+// slot stays empty and we avoid thrashing the cache with one-off collisions.
+func TestStringCacheNoAdmissionOnSlotCollision(t *testing.T) {
+	cache := newStringCache()
+	const slotCount = uint(4096)
+	data := make([]byte, slotCount+5)
+	for i := range data {
+		data[i] = 'a' + byte(i%26)
+	}
+
+	const offsetA, offsetB uint = 0, slotCount
+	require.Equal(t, offsetA%slotCount, offsetB%slotCount,
+		"test setup requires colliding slots")
+
+	for range 4 {
+		_ = cache.internAt(offsetA, 5, data)
+		require.Nil(t, cache.entries[offsetA%slotCount].Load(),
+			"alternating offsets must not admit at offsetA miss")
+		_ = cache.internAt(offsetB, 5, data)
+		require.Nil(t, cache.entries[offsetB%slotCount].Load(),
+			"alternating offsets must not admit at offsetB miss")
+	}
+}
+
+// TestStringCacheConcurrent stresses the lock-free cache with multiple
+// goroutines hammering shared offsets. With -race this catches torn reads
+// and admission-race bugs; without -race it still verifies that returned
+// strings always carry the correct content under contention and that hot
+// offsets are eventually admitted.
+func TestStringCacheConcurrent(t *testing.T) {
+	cache := newStringCache()
+	data := []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJ")
+
+	offsets := []uint{0, 5, 11, 17, 23}
+	const size = uint(5)
+	expected := make([]string, len(offsets))
+	for i, off := range offsets {
+		expected[i] = string(data[off : off+size])
+	}
+
+	const goroutines = 16
+	const iterations = 5000
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for iter := range iterations {
+				idx := iter % len(offsets)
+				got := cache.internAt(offsets[idx], size, data)
+				if got != expected[idx] {
+					t.Errorf("at offset %d got %q, want %q",
+						offsets[idx], got, expected[idx])
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+
+	for i, off := range offsets {
+		entry := cache.entries[off%uint(len(cache.entries))].Load()
+		require.NotNil(t, entry,
+			"hot offset %d (slot %d) should be admitted after concurrent stress",
+			off, off%uint(len(cache.entries)))
+		require.Equal(t, off, entry.offset)
+		require.Equal(t, expected[i], entry.str)
+	}
+}
+
+func BenchmarkStringCacheHot(b *testing.B) {
+	cache := newStringCache()
+	data := []byte("hello world, this is test data")
+
+	for b.Loop() {
+		benchmarkStringCacheSink = cache.internAt(0, 5, data)
+	}
+}
+
+func BenchmarkStringCacheCold(b *testing.B) {
+	cache := newStringCache()
+	data := make([]byte, 8192)
+	for i := range data {
+		data[i] = 'a' + byte(i%26)
+	}
+
+	var offset uint
+	for b.Loop() {
+		benchmarkStringCacheSink = cache.internAt(offset, 5, data)
+		offset += 7
+		if offset+5 >= uint(len(data)) {
+			offset = 0
+		}
 	}
 }

--- a/reader.go
+++ b/reader.go
@@ -603,6 +603,40 @@ func (r *Reader) traverseTree24(ip netip.Addr, node uint, stopBit int) (uint, in
 	if ip.Is4() {
 		i = r.ipv4StartBitDepth
 		node = r.ipv4Start
+
+		if stopBit <= i {
+			return node, i, nil
+		}
+
+		nodeCount := r.Metadata.NodeCount
+		buffer := r.buffer
+		bufferLen := uint(len(buffer))
+		ip4 := ip.As4()
+		ipBits := uint32(ip4[0])<<24 |
+			uint32(ip4[1])<<16 |
+			uint32(ip4[2])<<8 |
+			uint32(ip4[3])
+		remainingBits := min(stopBit-i, 32)
+
+		j := 0
+		for ; j < remainingBits && node < nodeCount; j++ {
+			baseOffset := node * 6
+			bit := uint((ipBits >> 31) & 1)
+			ipBits <<= 1
+			offset := baseOffset + bit*3
+
+			if !hasBufferRange(bufferLen, baseOffset, 6) {
+				return 0, 0, mmdberrors.NewInvalidDatabaseError(
+					"bounds check failed during tree traversal",
+				)
+			}
+
+			node = (uint(buffer[offset]) << 16) |
+				(uint(buffer[offset+1]) << 8) |
+				uint(buffer[offset+2])
+		}
+
+		return node, i + j, nil
 	}
 	nodeCount := r.Metadata.NodeCount
 	buffer := r.buffer
@@ -634,8 +668,62 @@ func (r *Reader) traverseTree24(ip netip.Addr, node uint, stopBit int) (uint, in
 func (r *Reader) traverseTree28(ip netip.Addr, node uint, stopBit int) (uint, int, error) {
 	i := 0
 	if ip.Is4() {
+		// Fast path: skip the IPv6 prefix bits by jumping directly to the
+		// IPv4 subtree root. The 32 IPv4 bits are packed into a uint32
+		// (ipBits) so we can extract each next bit with a single shift,
+		// avoiding the byteIdx/bitPos arithmetic the generic IPv6 path
+		// needs.
 		i = r.ipv4StartBitDepth
 		node = r.ipv4Start
+
+		if stopBit <= i {
+			return node, i, nil
+		}
+
+		nodeCount := r.Metadata.NodeCount
+		buffer := r.buffer
+		bufferLen := uint(len(buffer))
+		ip4 := ip.As4()
+		ipBits := uint32(ip4[0])<<24 |
+			uint32(ip4[1])<<16 |
+			uint32(ip4[2])<<8 |
+			uint32(ip4[3])
+		// stopBit comes from the shared traverseTree signature (max 128),
+		// but ipBits only holds 32 bits, so clamp before iterating.
+		remainingBits := min(stopBit-i, 32)
+
+		j := 0
+		for ; j < remainingBits && node < nodeCount; j++ {
+			// 28-bit record layout: each pair of records occupies 7 bytes.
+			// bit=0 reads buffer[base..base+3] high-nibble half; bit=1 reads
+			// buffer[base+4..base+6] low-nibble half. A single 7-byte range
+			// check covers both halves and is strictly stronger than the
+			// IPv6 path's two separate (base, 4) and (offset, 3) checks.
+			baseOffset := node * 7
+			bit := uint((ipBits >> 31) & 1)
+			ipBits <<= 1
+			offset := baseOffset + bit*4
+
+			if !hasBufferRange(bufferLen, baseOffset, 7) {
+				return 0, 0, mmdberrors.NewInvalidDatabaseError(
+					"bounds check failed during tree traversal",
+				)
+			}
+
+			// shift = 20 (bit=0) or 24 (bit=1): position the shared nibble's
+			// high or low 4 bits into the top of the assembled 28-bit node.
+			sharedByte := uint(buffer[baseOffset+3])
+			mask := uint(0xF0 >> (bit * 4))
+			shift := 20 + bit*4
+			nibble := ((sharedByte & mask) << shift)
+
+			node = nibble |
+				(uint(buffer[offset]) << 16) |
+				(uint(buffer[offset+1]) << 8) |
+				uint(buffer[offset+2])
+		}
+
+		return node, i + j, nil
 	}
 	nodeCount := r.Metadata.NodeCount
 	buffer := r.buffer
@@ -676,6 +764,41 @@ func (r *Reader) traverseTree32(ip netip.Addr, node uint, stopBit int) (uint, in
 	if ip.Is4() {
 		i = r.ipv4StartBitDepth
 		node = r.ipv4Start
+
+		if stopBit <= i {
+			return node, i, nil
+		}
+
+		nodeCount := r.Metadata.NodeCount
+		buffer := r.buffer
+		bufferLen := uint(len(buffer))
+		ip4 := ip.As4()
+		ipBits := uint32(ip4[0])<<24 |
+			uint32(ip4[1])<<16 |
+			uint32(ip4[2])<<8 |
+			uint32(ip4[3])
+		remainingBits := min(stopBit-i, 32)
+
+		j := 0
+		for ; j < remainingBits && node < nodeCount; j++ {
+			baseOffset := node * 8
+			bit := uint((ipBits >> 31) & 1)
+			ipBits <<= 1
+			offset := baseOffset + bit*4
+
+			if !hasBufferRange(bufferLen, baseOffset, 8) {
+				return 0, 0, mmdberrors.NewInvalidDatabaseError(
+					"bounds check failed during tree traversal",
+				)
+			}
+
+			node = (uint(buffer[offset]) << 24) |
+				(uint(buffer[offset+1]) << 16) |
+				(uint(buffer[offset+2]) << 8) |
+				uint(buffer[offset+3])
+		}
+
+		return node, i + j, nil
 	}
 	nodeCount := r.Metadata.NodeCount
 	buffer := r.buffer

--- a/reader_test.go
+++ b/reader_test.go
@@ -691,6 +691,214 @@ func TestIpv6inIpv4(t *testing.T) {
 	require.NoError(t, reader.Close(), "error on close")
 }
 
+// TestLookupIPv4VsIPv6Mixed guards the specialized IPv4 tree walks in
+// traverseTree24, traverseTree28, and traverseTree32 against drift
+// from the generic IPv6 walk. For each address we look up the IPv4
+// form (which hits the inline fast path) and the IPv4-mapped IPv6
+// form ::ffff:a.b.c.d (which goes through the generic walk) and
+// require them to reach the same leaf and decode to the same record.
+// A divergence would catch off-by-ones in the bit-extraction, the
+// remainingBits>32 clamp, or the merged bounds check in any
+// record-size variant.
+func TestLookupIPv4VsIPv6Mixed(t *testing.T) {
+	dbFiles := []string{
+		"MaxMind-DB-test-mixed-24.mmdb",
+		"MaxMind-DB-test-mixed-28.mmdb",
+		"MaxMind-DB-test-mixed-32.mmdb",
+	}
+
+	// Addresses spanning the range present in the test databases
+	// (1.1.1.0 through 1.1.1.32). A few outside-range probes confirm
+	// the not-found case stays consistent too.
+	addrs := []string{
+		"1.1.1.1",
+		"1.1.1.2",
+		"1.1.1.3",
+		"1.1.1.4",
+		"1.1.1.16",
+		"1.1.1.32",
+		"1.1.1.128",
+		"8.8.8.8",
+		"255.255.255.255",
+	}
+
+	for _, dbFile := range dbFiles {
+		t.Run(dbFile, func(t *testing.T) {
+			reader, err := Open(testFile(dbFile))
+			require.NoError(t, err)
+			defer func() { require.NoError(t, reader.Close()) }()
+
+			for _, s := range addrs {
+				t.Run(s, func(t *testing.T) {
+					v4 := netip.MustParseAddr(s)
+					v6 := netip.MustParseAddr("::ffff:" + s)
+					require.True(t, v4.Is4())
+					require.False(t, v6.Is4(),
+						"::ffff: form must not be Is4()")
+
+					r4 := reader.Lookup(v4)
+					r6 := reader.Lookup(v6)
+					require.NoError(t, r4.Err())
+					require.NoError(t, r6.Err())
+					require.Equal(t, r4.Found(), r6.Found(),
+						"IPv4 fast path and IPv6 generic walk disagree on Found")
+					require.Equal(t, r4.Offset(), r6.Offset(),
+						"IPv4 fast path and IPv6 generic walk reached different data records")
+
+					// Prefix() returns different shapes — IPv4 address space
+					// for r4 vs IPv4-mapped IPv6 space for r6 — so direct
+					// equality fails. After converting r6 to IPv4 form, the
+					// network must match. This catches drift in the fast
+					// path's depth bookkeeping that Offset()/Decode() miss.
+					p4, p6 := r4.Prefix(), r6.Prefix()
+					require.Equal(t, p4.Bits()+reader.ipv4StartBitDepth, p6.Bits(),
+						"IPv4 fast-path depth must align with IPv6 walk")
+					require.Equal(t, p4.Addr(), p6.Addr().Unmap(),
+						"IPv4 fast-path prefix address must match unmapped IPv6 prefix address")
+
+					var rec4, rec6 any
+					require.NoError(t, r4.Decode(&rec4))
+					require.NoError(t, r6.Decode(&rec6))
+					require.Equal(t, rec4, rec6,
+						"IPv4 fast path and IPv6 generic walk reached different leaves")
+				})
+			}
+		})
+	}
+}
+
+// TestLookupIPv4OnlyDB exercises the IPv4 specialized walks against
+// IPv4-only databases (ipv4StartBitDepth=96, ipv4Start=0). The mixed-DB
+// parity test guards traversal drift via the IPv4-mapped IPv6 walk, but
+// IPv4-only DBs have no IPv6 form to compare against. This test instead
+// asserts cross-record-size consistency: looking up the same IP in
+// size-24, size-28, and size-32 DBs must yield the same Found, Prefix,
+// and decoded record — any of the three fast paths returning a wrong
+// depth or wrong node would diverge.
+func TestLookupIPv4OnlyDB(t *testing.T) {
+	dbFiles := []string{
+		"MaxMind-DB-test-ipv4-24.mmdb",
+		"MaxMind-DB-test-ipv4-28.mmdb",
+		"MaxMind-DB-test-ipv4-32.mmdb",
+	}
+	readers := make([]*Reader, len(dbFiles))
+	for i, dbFile := range dbFiles {
+		r, err := Open(testFile(dbFile))
+		require.NoError(t, err)
+		readers[i] = r
+	}
+	t.Cleanup(func() {
+		for _, r := range readers {
+			require.NoError(t, r.Close())
+		}
+	})
+
+	addrs := []string{
+		"1.1.1.1",
+		"1.1.1.2",
+		"1.1.1.32",
+		"1.1.1.128",
+		"8.8.8.8",
+		"255.255.255.255",
+	}
+
+	for _, s := range addrs {
+		t.Run(s, func(t *testing.T) {
+			ip := netip.MustParseAddr(s)
+			require.True(t, ip.Is4())
+
+			results := make([]Result, len(readers))
+			for i, r := range readers {
+				results[i] = r.Lookup(ip)
+				require.NoError(t, results[i].Err())
+
+				p := results[i].Prefix()
+				require.True(t, p.Addr().Is4(),
+					"%s: IPv4 lookup must produce an IPv4-shaped prefix", dbFiles[i])
+				require.LessOrEqual(t, p.Bits(), 32,
+					"%s: IPv4 prefix bits must fit in [0,32]", dbFiles[i])
+			}
+
+			// Cross-record-size consistency: the same IP must land at
+			// the same leaf in all three databases.
+			for i := 1; i < len(results); i++ {
+				require.Equal(t, results[0].Found(), results[i].Found(),
+					"%s vs %s disagree on Found", dbFiles[0], dbFiles[i])
+				require.Equal(t, results[0].Prefix(), results[i].Prefix(),
+					"%s vs %s disagree on Prefix", dbFiles[0], dbFiles[i])
+
+				if !results[0].Found() {
+					continue
+				}
+				var rec0, recI any
+				require.NoError(t, results[0].Decode(&rec0))
+				require.NoError(t, results[i].Decode(&recI))
+				require.Equal(t, rec0, recI,
+					"%s vs %s disagree on decoded record", dbFiles[0], dbFiles[i])
+			}
+		})
+	}
+}
+
+// TestTraverseIPv4TreeBoundsCheck isolates the bounds-check error path
+// added to the specialized IPv4 walks at reader.go:625-629, 699-703,
+// 786-790. The generic IPv6 walk has its own bounds checks elsewhere;
+// without a focused test, a regression in the IPv4 fast-path checks
+// (e.g. a `<=` flipped to `<` in hasBufferRange, or a wrong record
+// size) would not be caught by TestVerifyOnBrokenDatabases (which
+// covers only 24-record-size at the verifier level, not lookup).
+//
+// Approach: construct a Reader with an empty buffer and a non-zero
+// NodeCount, then call each traverseTreeNN directly with an IPv4
+// address. The fast path enters its loop, attempts to read the
+// first node's bytes, and must surface the bounds-check error.
+func TestTraverseIPv4TreeBoundsCheck(t *testing.T) {
+	cases := []struct {
+		name       string
+		recordSize uint
+		traverse   func(*Reader) error
+	}{
+		{
+			name:       "tree24",
+			recordSize: 24,
+			traverse: func(r *Reader) error {
+				_, _, err := r.traverseTree24(netip.MustParseAddr("1.2.3.4"), 0, 128)
+				return err
+			},
+		},
+		{
+			name:       "tree28",
+			recordSize: 28,
+			traverse: func(r *Reader) error {
+				_, _, err := r.traverseTree28(netip.MustParseAddr("1.2.3.4"), 0, 128)
+				return err
+			},
+		},
+		{
+			name:       "tree32",
+			recordSize: 32,
+			traverse: func(r *Reader) error {
+				_, _, err := r.traverseTree32(netip.MustParseAddr("1.2.3.4"), 0, 128)
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Reader{
+				buffer:            []byte{}, // empty: any node read overruns
+				Metadata:          Metadata{NodeCount: 1, RecordSize: tc.recordSize},
+				ipv4StartBitDepth: 96,
+				ipv4Start:         0,
+			}
+			err := tc.traverse(r)
+			require.Error(t, err)
+			require.ErrorContains(t, err, "bounds check failed during tree traversal")
+		})
+	}
+}
+
 func TestBrokenDoubleDatabase(t *testing.T) {
 	reader, err := Open(testFile("GeoIP2-City-Test-Broken-Double-Format.mmdb"))
 	require.NoError(t, err, "unexpected error while opening database: %v", err)

--- a/reader_test.go
+++ b/reader_test.go
@@ -911,71 +911,100 @@ func BenchmarkLookupNetwork(b *testing.B) {
 	require.NoError(b, db.Close(), "error on close")
 }
 
-type fullCity struct {
-	City struct {
-		GeoNameID uint              `maxminddb:"geoname_id"`
-		Names     map[string]string `maxminddb:"names"`
-	} `maxminddb:"city"`
-	Continent struct {
-		Code      string            `maxminddb:"code"`
-		GeoNameID uint              `maxminddb:"geoname_id"`
-		Names     map[string]string `maxminddb:"names"`
-	} `maxminddb:"continent"`
-	Country struct {
-		GeoNameID         uint              `maxminddb:"geoname_id"`
-		IsInEuropeanUnion bool              `maxminddb:"is_in_european_union"`
-		IsoCode           string            `maxminddb:"iso_code"`
-		Names             map[string]string `maxminddb:"names"`
-	} `maxminddb:"country"`
-	Location struct {
-		AccuracyRadius uint16  `maxminddb:"accuracy_radius"`
-		Latitude       float64 `maxminddb:"latitude"`
-		Longitude      float64 `maxminddb:"longitude"`
-		MetroCode      uint    `maxminddb:"metro_code"`
-		TimeZone       string  `maxminddb:"time_zone"`
-	} `maxminddb:"location"`
-	Postal struct {
-		Code string `maxminddb:"code"`
-	} `maxminddb:"postal"`
-	RegisteredCountry struct {
-		GeoNameID         uint              `maxminddb:"geoname_id"`
-		IsInEuropeanUnion bool              `maxminddb:"is_in_european_union"`
-		IsoCode           string            `maxminddb:"iso_code"`
-		Names             map[string]string `maxminddb:"names"`
-	} `maxminddb:"registered_country"`
-	RepresentedCountry struct {
-		GeoNameID         uint              `maxminddb:"geoname_id"`
-		IsInEuropeanUnion bool              `maxminddb:"is_in_european_union"`
-		IsoCode           string            `maxminddb:"iso_code"`
-		Names             map[string]string `maxminddb:"names"`
-		Type              string            `maxminddb:"type"`
-	} `maxminddb:"represented_country"`
-	Subdivisions []struct {
-		GeoNameID uint              `maxminddb:"geoname_id"`
-		IsoCode   string            `maxminddb:"iso_code"`
-		Names     map[string]string `maxminddb:"names"`
-	} `maxminddb:"subdivisions"`
-	Traits struct {
-		IsAnonymousProxy    bool `maxminddb:"is_anonymous_proxy"`
-		IsSatelliteProvider bool `maxminddb:"is_satellite_provider"`
-	} `maxminddb:"traits"`
+type benchmarkNames struct {
+	German              string `maxminddb:"de"`
+	English             string `maxminddb:"en"`
+	Spanish             string `maxminddb:"es"`
+	French              string `maxminddb:"fr"`
+	Japanese            string `maxminddb:"ja"`
+	BrazilianPortuguese string `maxminddb:"pt-BR"`
+	Russian             string `maxminddb:"ru"`
+	SimplifiedChinese   string `maxminddb:"zh-CN"`
 }
 
+type benchmarkContinent struct {
+	Names     benchmarkNames `maxminddb:"names"`
+	Code      string         `maxminddb:"code"`
+	GeoNameID uint           `maxminddb:"geoname_id"`
+}
+
+type benchmarkLocation struct {
+	Latitude       *float64 `maxminddb:"latitude"`
+	Longitude      *float64 `maxminddb:"longitude"`
+	TimeZone       string   `maxminddb:"time_zone"`
+	MetroCode      uint     `maxminddb:"metro_code"`
+	AccuracyRadius uint16   `maxminddb:"accuracy_radius"`
+}
+
+type benchmarkRepresentedCountry struct {
+	Names             benchmarkNames `maxminddb:"names"`
+	ISOCode           string         `maxminddb:"iso_code"`
+	Type              string         `maxminddb:"type"`
+	GeoNameID         uint           `maxminddb:"geoname_id"`
+	IsInEuropeanUnion bool           `maxminddb:"is_in_european_union"`
+}
+
+type benchmarkCityRecord struct {
+	Names     benchmarkNames `maxminddb:"names"`
+	GeoNameID uint           `maxminddb:"geoname_id"`
+}
+
+type benchmarkCityPostal struct {
+	Code string `maxminddb:"code"`
+}
+
+type benchmarkCitySubdivision struct {
+	Names     benchmarkNames `maxminddb:"names"`
+	ISOCode   string         `maxminddb:"iso_code"`
+	GeoNameID uint           `maxminddb:"geoname_id"`
+}
+
+type benchmarkCountryRecord struct {
+	Names             benchmarkNames `maxminddb:"names"`
+	ISOCode           string         `maxminddb:"iso_code"`
+	GeoNameID         uint           `maxminddb:"geoname_id"`
+	IsInEuropeanUnion bool           `maxminddb:"is_in_european_union"`
+}
+
+type benchmarkCityTraits struct {
+	IPAddress netip.Addr
+	Network   netip.Prefix
+	IsAnycast bool `maxminddb:"is_anycast"`
+}
+
+type benchmarkCity struct {
+	Traits             benchmarkCityTraits         `maxminddb:"traits"`
+	Postal             benchmarkCityPostal         `maxminddb:"postal"`
+	Continent          benchmarkContinent          `maxminddb:"continent"`
+	City               benchmarkCityRecord         `maxminddb:"city"`
+	Subdivisions       []benchmarkCitySubdivision  `maxminddb:"subdivisions"`
+	RepresentedCountry benchmarkRepresentedCountry `maxminddb:"represented_country"`
+	Country            benchmarkCountryRecord      `maxminddb:"country"`
+	RegisteredCountry  benchmarkCountryRecord      `maxminddb:"registered_country"`
+	Location           benchmarkLocation           `maxminddb:"location"`
+}
+
+// benchmarkCity mirrors geoip2-golang's City result shape, and the city
+// lookup benchmarks below also populate Traits.IPAddress and Traits.Network to
+// match geoip2.Reader.City's post-decode work.
 func BenchmarkCityLookup(b *testing.B) {
 	db, err := Open("GeoLite2-City.mmdb")
 	require.NoError(b, err)
 
 	//nolint:gosec // this is a test
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	var result fullCity
+	var result benchmarkCity
 
 	s := make(net.IP, 4)
 	for b.Loop() {
 		ip := randomIPv4Address(r, s)
-		err = db.Lookup(ip).Decode(&result)
+		lookupResult := db.Lookup(ip)
+		err = lookupResult.Decode(&result)
 		if err != nil {
 			b.Error(err)
 		}
+		result.Traits.IPAddress = ip
+		result.Traits.Network = lookupResult.Prefix()
 	}
 	require.NoError(b, db.Close(), "error on close")
 }
@@ -1073,15 +1102,18 @@ func BenchmarkCityLookupConcurrent(b *testing.B) {
 						//nolint:gosec // this is a test
 						r := rand.New(rand.NewSource(time.Now().UnixNano()))
 						s := make(net.IP, 4)
-						var result fullCity
+						var result benchmarkCity
 
 						for range lookupsPerGoroutine {
 							ip := randomIPv4Address(r, s)
-							err := db.Lookup(ip).Decode(&result)
+							lookupResult := db.Lookup(ip)
+							err := lookupResult.Decode(&result)
 							if err != nil {
 								b.Error(err)
 								return
 							}
+							result.Traits.IPAddress = ip
+							result.Traits.Network = lookupResult.Prefix()
 							// Access string fields to exercise the cache
 							_ = result.City.Names
 							_ = result.Country.Names


### PR DESCRIPTION
## Summary

Performance work on the reflection-based decoder and the search-tree walk. A city-lookup benchmark decoding a geoip2-style result runs about 15% faster and allocates about 39% fewer bytes per lookup vs. 2.2.0.

Headline changes:

- Reflection decoder hot path: skip the boxing copy on the common \`Decode(&v)\` entry, reuse slice backing arrays, precompute the unmarshaler-check dispatch per struct type, add a \`reflect.Uint\` fast path, inline the control-byte size-encoding switch, and fast-path inline string keys.
- String cache: drop per-entry RWMutex in favor of \`atomic.Pointer\` reads with a two-miss admission policy to reduce contention under concurrent lookups.
- Search tree: specialize the IPv4 walk in \`traverseTree24\`, \`traverseTree28\`, and \`traverseTree32\` so the IPv4 case skips the IPv6 prefix, packs the address into a \`uint32\`, and uses a single per-iteration bounds check.

The city benchmark was also reshaped to mirror geoip2-golang's result struct so the comparison is apples-to-apples.

Numbers come from \`benchstat\` of \`BenchmarkCityLookupCompare\` (a temporary equivalent benchmark with renamed types, applied to both \`origin/main\` and this branch) over 30 interleaved samples per side: 2.132µs → 1.819µs (−14.70%, p=0.000) and 131B → 80B (−38.93%, p=0.000).

## Test plan

- [x] \`go test -race ./...\` clean
- [x] \`go vet ./...\` clean
- [x] New \`TestLookupIPv4VsIPv6Mixed\` asserts the specialized IPv4 walks reach the same leaf as the generic IPv6 walk for \`mixed-24\`, \`mixed-28\`, and \`mixed-32\` databases
- [x] New \`TestStringCacheTwoMissAdmission\` and \`TestStringCacheNoAdmissionOnSlotCollision\` verify the cache's admission policy
- [x] New \`TestDecodeSliceClearsTailReferences\` verifies the slice backing-array reuse zeroes the now-hidden tail so dropped element references can be GC'd
- [x] \`benchstat\` confirms no regressions on the other benchmarks (\`BenchmarkLookupNetwork\`, \`BenchmarkCityLookupOnly\`, \`BenchmarkStringCache*\`, \`BenchmarkInterfaceLookup\`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Faster reflection-based decoding with fewer allocations, expanded fast paths, slice reuse, and safer uint handling
  * Lock-free string cache to reduce contention and improve string interning
  * IPv4-specific traversal fast path for faster lookups
* **Documentation**
  * Added 2.3.0 changelog entry; Requirements updated to Go 1.25+
* **Tests**
  * New regression tests and benchmarks for decoding, caching, and IPv4/IPv6 traversal
* **CI**
  * CI matrix updated to run on Go 1.25+

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oschwald/maxminddb-golang/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->