### PR TITLE
Optimize decoder pointer handling and field caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Optimized map key decoding by adding a fast path for pointer keys, improving
   general lookup throughput by 2.7% to 6.4%.
 - Optimized tree traversal for IPv6 lookups, resulting in an ~8.8% speedup.
+- Fixed pointer-to-pointer chains in malformed database data so decoder entry
+  points reject them consistently instead of following invalid chains.
 - Reduced memory mapping overhead and system allocations when invoking `OpenBytes`
   and `NetworksWithin`.
 - Cleaned up, simplified, and deduplicated internal decoder and reader structures,

--- a/internal/decoder/data_decoder.go
+++ b/internal/decoder/data_decoder.go
@@ -550,9 +550,10 @@ func (d *DataDecoder) nextValueOffset(offset, numberToSkip uint) (uint, error) {
 			// A pointer value is represented by its pointer token only.
 			// To skip it, just move past the pointer bytes; do NOT follow
 			// the pointer target here.
-			_, ptrEndOffset, err2 := d.decodePointer(size, newOffset)
-			if err2 != nil {
-				return 0, err2
+			pointerSize := ((size >> 3) & 0x3) + 1
+			ptrEndOffset := newOffset + pointerSize
+			if ptrEndOffset > uint(len(d.buffer)) {
+				return 0, mmdberrors.NewOffsetError()
 			}
 			newOffset = ptrEndOffset
 		case KindMap:

--- a/internal/decoder/data_decoder_test.go
+++ b/internal/decoder/data_decoder_test.go
@@ -267,3 +267,21 @@ func TestDecodePointerKeyFastExtendedSize(t *testing.T) {
 	require.Equal(t, uint(2), nextOffset,
 		"nextOffset must point past the pointer bytes regardless of fast/slow path")
 }
+
+func TestNextValueOffsetSkipsPointerTokenOnly(t *testing.T) {
+	// The pointer at offset 0 has a deliberately bogus target. Skipping it
+	// should only move past the pointer token so the following string can be
+	// read; it should not decode or validate the target value.
+	d := NewDataDecoder([]byte{0x20, 0x04, 0x42, 'o', 'k'})
+
+	nextOffset, err := d.nextValueOffset(0, 1)
+	require.NoError(t, err)
+	require.Equal(t, uint(2), nextOffset)
+
+	kind, size, dataOffset, err := d.decodeCtrlData(nextOffset)
+	require.NoError(t, err)
+	require.Equal(t, KindString, kind)
+	got, _, err := d.decodeString(size, dataOffset)
+	require.NoError(t, err)
+	require.Equal(t, "ok", got)
+}

--- a/internal/decoder/decoder.go
+++ b/internal/decoder/decoder.go
@@ -331,39 +331,30 @@ func (d *Decoder) PeekKind() (Kind, error) {
 }
 
 // Offset returns the current offset position in the database.
-// If the current position points to a pointer, this method resolves the
-// pointer chain and returns the offset of the actual data. This ensures
+// If the current position points to a pointer, this method resolves one
+// pointer and returns the offset of the actual data. This ensures
 // that multiple pointers to the same data return the same offset, which
 // is important for caching purposes.
 func (d *Decoder) Offset() uint {
 	// This intentionally does not use resolveCtrlData: Offset must return the
 	// resolved value's control-byte offset, not the post-control-byte payload
 	// offset used by read methods.
-	dataOffset := d.offset
-	for {
-		kindNum, size, ctrlEndOffset, err := d.d.decodeCtrlData(dataOffset)
-		if err != nil {
-			// Return original offset to avoid breaking the public API.
-			// Offset() returns uint (not (uint, error)), so we can't propagate errors.
-			// In practice, errors here are rare and the original offset is still valid.
-			return d.offset
-		}
-		if kindNum != KindPointer {
-			// dataOffset is now pointing at the actual data (not a pointer)
-			// Return this offset, which is where the data's control bytes start
-			break
-		}
-
-		// Follow the pointer to get the target offset
-		dataOffset, _, err = d.d.decodePointer(size, ctrlEndOffset)
-		if err != nil {
-			// Return original offset to avoid breaking the public API.
-			// The caller will encounter the same error when they try to read.
-			return d.offset
-		}
-		// dataOffset is now the pointer target; loop to check if it's also a pointer
+	kindNum, size, ctrlEndOffset, err := d.d.decodeCtrlData(d.offset)
+	if err != nil || kindNum != KindPointer {
+		return d.offset
 	}
-	return dataOffset
+
+	pointer, _, err := d.d.decodePointer(size, ctrlEndOffset)
+	if err != nil {
+		// Return original offset to avoid breaking the public API.
+		// The caller will encounter the same error when they try to read.
+		return d.offset
+	}
+	kindNum, _, _, err = d.d.decodeCtrlData(pointer)
+	if err != nil || kindNum == KindPointer {
+		return d.offset
+	}
+	return pointer
 }
 
 func (d *Decoder) reset(offset uint) {

--- a/internal/decoder/decoder.go
+++ b/internal/decoder/decoder.go
@@ -397,11 +397,11 @@ func (d *Decoder) decodeCtrlDataAndFollow(expectedKind Kind) (uint, uint, error)
 	return size, dataOffset, nil
 }
 
-// resolveCtrlData follows any pointer chain starting at offset and returns the
-// control data for the final non-pointer value. Unlike decodeCtrlData, which
-// reads exactly one control record, this helper also reports the first pointer's
-// end offset so callers can preserve the decoder's sequential "next value"
-// position after resolving indirections.
+// resolveCtrlData resolves at most one pointer starting at offset and returns
+// the control data for the non-pointer value. Unlike decodeCtrlData, which
+// reads exactly one control record, this helper also reports the pointer's end
+// offset so callers can preserve the decoder's sequential "next value" position
+// after resolving indirection. Pointer-to-pointer data is invalid.
 //
 // nextOffset is 0 when offset already pointed at a non-pointer value (no
 // indirection was followed). Callers must check this before calling
@@ -411,25 +411,30 @@ func (d *Decoder) decodeCtrlDataAndFollow(expectedKind Kind) (uint, uint, error)
 func (d *Decoder) resolveCtrlData(
 	offset uint,
 ) (kind Kind, size, dataOffset, nextOffset uint, err error) {
-	dataOffset = offset
-	for {
-		kind, size, dataOffset, err = d.d.decodeCtrlData(dataOffset)
-		if err != nil {
-			return 0, 0, 0, 0, err
-		}
-		if kind != KindPointer {
-			return kind, size, dataOffset, nextOffset, nil
-		}
-
-		var pointerEndOffset uint
-		dataOffset, pointerEndOffset, err = d.d.decodePointer(size, dataOffset)
-		if err != nil {
-			return 0, 0, 0, 0, err
-		}
-		if nextOffset == 0 {
-			nextOffset = pointerEndOffset
-		}
+	kind, size, dataOffset, err = d.d.decodeCtrlData(offset)
+	if err != nil {
+		return 0, 0, 0, 0, err
 	}
+	if kind != KindPointer {
+		return kind, size, dataOffset, 0, nil
+	}
+
+	var pointerEndOffset uint
+	dataOffset, pointerEndOffset, err = d.d.decodePointer(size, dataOffset)
+	if err != nil {
+		return 0, 0, 0, 0, err
+	}
+	nextOffset = pointerEndOffset
+
+	kind, size, dataOffset, err = d.d.decodeCtrlData(dataOffset)
+	if err != nil {
+		return 0, 0, 0, 0, err
+	}
+	if kind == KindPointer {
+		return 0, 0, 0, 0, mmdberrors.NewInvalidDatabaseError("pointer-to-pointer chain detected")
+	}
+
+	return kind, size, dataOffset, nextOffset, nil
 }
 
 func (d *Decoder) readBytes(kind Kind) ([]byte, error) {

--- a/internal/decoder/decoder_test.go
+++ b/internal/decoder/decoder_test.go
@@ -596,3 +596,12 @@ func TestDecoderOptions(t *testing.T) {
 	decoder2 := NewDecoder(dd, 0)
 	require.NotNil(t, decoder2)
 }
+
+func TestPointerToPointerChain(t *testing.T) {
+	// Offset 0 points to offset 2. Offset 2 points to offset 4. Offset 4 is string "abc".
+	// Hex representation: "2002200443616263"
+	decoder := newDecoderFromHex(t, "2002200443616263")
+	_, err := decoder.ReadString()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "pointer-to-pointer chain detected")
+}

--- a/internal/decoder/decoder_test.go
+++ b/internal/decoder/decoder_test.go
@@ -501,11 +501,13 @@ func TestOffsetReturnsValueStart(t *testing.T) {
 		buffer         []byte
 		offset         uint
 		expectedOffset uint
+		expectedValue  string
 	}{
 		"direct value": {
 			buffer:         []byte{0x44, 't', 'e', 's', 't'},
 			offset:         0,
 			expectedOffset: 0,
+			expectedValue:  "test",
 		},
 		"pointer": {
 			buffer: []byte{
@@ -515,6 +517,17 @@ func TestOffsetReturnsValueStart(t *testing.T) {
 			},
 			offset:         0,
 			expectedOffset: 5,
+			expectedValue:  "test",
+		},
+		"pointer-to-pointer": {
+			buffer: []byte{
+				0x20, 0x02,
+				0x20, 0x05,
+				0x00,
+				0x44, 't', 'e', 's', 't',
+			},
+			offset:         0,
+			expectedOffset: 0,
 		},
 	}
 
@@ -524,11 +537,14 @@ func TestOffsetReturnsValueStart(t *testing.T) {
 			offset := NewDecoder(dd, tt.offset).Offset()
 
 			require.Equal(t, tt.expectedOffset, offset)
+			if tt.expectedValue == "" {
+				return
+			}
 
 			decoder := NewDecoder(dd, offset)
 			value, err := decoder.ReadString()
 			require.NoError(t, err)
-			require.Equal(t, "test", value)
+			require.Equal(t, tt.expectedValue, value)
 		})
 	}
 }

--- a/internal/decoder/field_precedence_test.go
+++ b/internal/decoder/field_precedence_test.go
@@ -168,3 +168,44 @@ func TestRecursivePointerStructFieldCaching(t *testing.T) {
 	require.Contains(t, fields.namedFields, "next")
 	assert.Nil(t, fields.namedFields["next"].structFields)
 }
+
+func TestPointerStructFieldCachingChecksDepth(t *testing.T) {
+	type inner struct {
+		En string `maxminddb:"en"`
+	}
+
+	fields := makeStructFields(reflect.TypeFor[inner]())
+	decoder := New([]byte{
+		0x20, 0x02,
+		0xe0,
+	})
+
+	t.Run("value struct", func(t *testing.T) {
+		var target inner
+		_, ok, err := decoder.tryDecodeStructWithFields(
+			0,
+			addressableValue{Value: reflect.ValueOf(&target).Elem()},
+			maximumDataStructureDepth,
+			fields,
+		)
+
+		require.True(t, ok)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeded maximum data structure depth")
+	})
+
+	t.Run("pointer struct", func(t *testing.T) {
+		var target *inner
+		_, ok, err := decoder.tryDecodePointerStructWithFields(
+			0,
+			addressableValue{Value: reflect.ValueOf(&target).Elem()},
+			maximumDataStructureDepth,
+			fields,
+		)
+
+		require.True(t, ok)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeded maximum data structure depth")
+		assert.Nil(t, target)
+	})
+}

--- a/internal/decoder/field_precedence_test.go
+++ b/internal/decoder/field_precedence_test.go
@@ -132,3 +132,39 @@ func TestFieldCaching(t *testing.T) {
 		assert.NotNil(t, fields1.namedFields[name], "Field info should not be nil: "+name)
 	}
 }
+
+func TestPointerStructFieldCaching(t *testing.T) {
+	type inner struct {
+		En string `maxminddb:"en"`
+	}
+
+	type outer struct {
+		Inner *inner `maxminddb:"inner"`
+	}
+
+	fields := makeStructFields(reflect.TypeFor[outer]())
+	require.Contains(t, fields.namedFields, "inner")
+	require.NotNil(t, fields.namedFields["inner"].structFields)
+
+	// Test data: {"inner": {"en": "Foo"}}
+	testData := "e145696e6e6572e142656e43466f6f"
+	testBytes, err := hex.DecodeString(testData)
+	require.NoError(t, err)
+
+	var target outer
+	decoder := New(testBytes)
+	require.NoError(t, decoder.Decode(0, &target))
+	require.NotNil(t, target.Inner)
+	assert.Equal(t, "Foo", target.Inner.En)
+}
+
+func TestRecursivePointerStructFieldCaching(t *testing.T) {
+	type node struct {
+		Next *node  `maxminddb:"next"`
+		Name string `maxminddb:"name"`
+	}
+
+	fields := makeStructFields(reflect.TypeFor[node]())
+	require.Contains(t, fields.namedFields, "next")
+	assert.Nil(t, fields.namedFields["next"].structFields)
+}

--- a/internal/decoder/field_precedence_test.go
+++ b/internal/decoder/field_precedence_test.go
@@ -175,37 +175,44 @@ func TestPointerStructFieldCachingChecksDepth(t *testing.T) {
 	}
 
 	fields := makeStructFields(reflect.TypeFor[inner]())
-	decoder := New([]byte{
-		0x20, 0x02,
-		0xe0,
-	})
+	tests := map[string][]byte{
+		"direct map": {0xe0},
+		"pointer": {
+			0x20, 0x02,
+			0xe0,
+		},
+	}
 
-	t.Run("value struct", func(t *testing.T) {
-		var target inner
-		_, ok, err := decoder.tryDecodeStructWithFields(
-			0,
-			addressableValue{Value: reflect.ValueOf(&target).Elem()},
-			maximumDataStructureDepth,
-			fields,
-		)
+	for name, data := range tests {
+		t.Run(name+"/value struct", func(t *testing.T) {
+			decoder := New(data)
+			var target inner
+			_, ok, err := decoder.tryDecodeStructWithFields(
+				0,
+				addressableValue{Value: reflect.ValueOf(&target).Elem()},
+				maximumDataStructureDepth,
+				fields,
+			)
 
-		require.True(t, ok)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "exceeded maximum data structure depth")
-	})
+			require.True(t, ok)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "exceeded maximum data structure depth")
+		})
 
-	t.Run("pointer struct", func(t *testing.T) {
-		var target *inner
-		_, ok, err := decoder.tryDecodePointerStructWithFields(
-			0,
-			addressableValue{Value: reflect.ValueOf(&target).Elem()},
-			maximumDataStructureDepth,
-			fields,
-		)
+		t.Run(name+"/pointer struct", func(t *testing.T) {
+			decoder := New(data)
+			var target *inner
+			_, ok, err := decoder.tryDecodePointerStructWithFields(
+				0,
+				addressableValue{Value: reflect.ValueOf(&target).Elem()},
+				maximumDataStructureDepth,
+				fields,
+			)
 
-		require.True(t, ok)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "exceeded maximum data structure depth")
-		assert.Nil(t, target)
-	})
+			require.True(t, ok)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "exceeded maximum data structure depth")
+			assert.Nil(t, target)
+		})
+	}
 }

--- a/internal/decoder/reflection.go
+++ b/internal/decoder/reflection.go
@@ -969,6 +969,9 @@ func (d *ReflectionDecoder) tryDecodeStructWithFields(
 		if err != nil {
 			return 0, true, err
 		}
+		if err := checkPointerDepth(depth); err != nil {
+			return 0, true, err
+		}
 		typeNum, size, dataOffset, err = d.decodeCtrlData(pointer)
 		if err != nil {
 			return 0, true, err
@@ -1011,6 +1014,9 @@ func (d *ReflectionDecoder) tryDecodePointerStructWithFields(
 		if err != nil {
 			return 0, true, err
 		}
+		if err := checkPointerDepth(depth); err != nil {
+			return 0, true, err
+		}
 		typeNum, size, dataOffset, err = d.decodeCtrlData(pointer)
 		if err != nil {
 			return 0, true, err
@@ -1036,6 +1042,15 @@ func (d *ReflectionDecoder) tryDecodePointerStructWithFields(
 		result,
 		decodeDepth,
 		fields,
+	)
+}
+
+func checkPointerDepth(depth int) error {
+	if depth+1 <= maximumDataStructureDepth {
+		return nil
+	}
+	return mmdberrors.NewInvalidDatabaseError(
+		"exceeded maximum data structure depth; database is likely corrupt",
 	)
 }
 

--- a/internal/decoder/reflection.go
+++ b/internal/decoder/reflection.go
@@ -962,6 +962,9 @@ func (d *ReflectionDecoder) tryDecodeStructWithFields(
 
 	switch typeNum {
 	case KindMap:
+		if err := checkNestedDepth(depth); err != nil {
+			return 0, true, err
+		}
 		newOffset, err = d.decodeStructWithFields(size, dataOffset, result, depth+1, fields)
 		return newOffset, true, err
 	case KindPointer:
@@ -969,7 +972,7 @@ func (d *ReflectionDecoder) tryDecodeStructWithFields(
 		if err != nil {
 			return 0, true, err
 		}
-		if err := checkPointerDepth(depth); err != nil {
+		if err := checkNestedDepth(depth); err != nil {
 			return 0, true, err
 		}
 		typeNum, size, dataOffset, err = d.decodeCtrlData(pointer)
@@ -1007,6 +1010,9 @@ func (d *ReflectionDecoder) tryDecodePointerStructWithFields(
 	decodeDepth := depth + 1
 	switch typeNum {
 	case KindMap:
+		if err := checkNestedDepth(depth); err != nil {
+			return 0, true, err
+		}
 		// Use the map control record we already decoded.
 	case KindPointer:
 		var pointer uint
@@ -1014,7 +1020,7 @@ func (d *ReflectionDecoder) tryDecodePointerStructWithFields(
 		if err != nil {
 			return 0, true, err
 		}
-		if err := checkPointerDepth(depth); err != nil {
+		if err := checkNestedDepth(depth); err != nil {
 			return 0, true, err
 		}
 		typeNum, size, dataOffset, err = d.decodeCtrlData(pointer)
@@ -1045,8 +1051,8 @@ func (d *ReflectionDecoder) tryDecodePointerStructWithFields(
 	)
 }
 
-func checkPointerDepth(depth int) error {
-	if depth+1 <= maximumDataStructureDepth {
+func checkNestedDepth(depth int) error {
+	if depth < maximumDataStructureDepth {
 		return nil
 	}
 	return mmdberrors.NewInvalidDatabaseError(

--- a/internal/decoder/reflection.go
+++ b/internal/decoder/reflection.go
@@ -852,6 +852,16 @@ func (d *ReflectionDecoder) decodeStruct(
 	depth int,
 ) (uint, error) {
 	fields := cachedFields(result.Value)
+	return d.decodeStructWithFields(size, offset, result, depth, fields)
+}
+
+func (d *ReflectionDecoder) decodeStructWithFields(
+	size uint,
+	offset uint,
+	result addressableValue,
+	depth int,
+	fields *fieldsType,
+) (uint, error) {
 	if fields.validationErr != nil {
 		return 0, fields.validationErr
 	}
@@ -908,6 +918,18 @@ func (d *ReflectionDecoder) decodeStruct(
 		case dispatchUnmarshaler:
 			offset, err = d.decodeValue(offset, fieldValue, depth)
 		default: // dispatchPlain
+			if fieldInfo.structFields != nil {
+				var ok bool
+				offset, ok, err = d.tryDecodeStructWithFields(
+					offset,
+					fieldValue,
+					depth,
+					fieldInfo.structFields,
+				)
+				if ok {
+					break
+				}
+			}
 			offset, err = d.decodeValueSkipUnmarshaler(offset, fieldValue, depth)
 		}
 		if err != nil {
@@ -915,6 +937,46 @@ func (d *ReflectionDecoder) decodeStruct(
 		}
 	}
 	return offset, nil
+}
+
+func (d *ReflectionDecoder) tryDecodeStructWithFields(
+	offset uint,
+	result addressableValue,
+	depth int,
+	fields *fieldsType,
+) (newOffset uint, ok bool, err error) {
+	typeNum, size, dataOffset, err := d.decodeCtrlData(offset)
+	if err != nil {
+		return 0, true, err
+	}
+
+	switch typeNum {
+	case KindMap:
+		newOffset, err = d.decodeStructWithFields(size, dataOffset, result, depth+1, fields)
+		return newOffset, true, err
+	case KindPointer:
+		pointer, pointerEndOffset, err := d.decodePointer(size, dataOffset)
+		if err != nil {
+			return 0, true, err
+		}
+		typeNum, size, dataOffset, err = d.decodeCtrlData(pointer)
+		if err != nil {
+			return 0, true, err
+		}
+		if typeNum == KindPointer {
+			return 0, true, mmdberrors.NewInvalidDatabaseError(
+				"invalid pointer to pointer at offset %d",
+				pointer,
+			)
+		}
+		if typeNum != KindMap {
+			return 0, false, nil
+		}
+		_, err = d.decodeStructWithFields(size, dataOffset, result, depth+2, fields)
+		return pointerEndOffset, true, err
+	default:
+		return 0, false, nil
+	}
 }
 
 // fieldDispatch encodes the decode strategy for a struct field, computed
@@ -942,13 +1004,14 @@ const (
 )
 
 type fieldInfo struct {
-	fieldType reflect.Type
-	name      string
-	index     []int
-	index0    int
-	depth     int
-	hasTag    bool
-	dispatch  fieldDispatch
+	fieldType    reflect.Type
+	structFields *fieldsType
+	name         string
+	index        []int
+	index0       int
+	depth        int
+	hasTag       bool
+	dispatch     fieldDispatch
 }
 
 type fieldsType struct {
@@ -1038,8 +1101,10 @@ func mayImplementUnmarshaler(t reflect.Type) bool {
 }
 
 func cachedFields(result reflect.Value) *fieldsType {
-	resultType := result.Type()
+	return cachedFieldsForType(result.Type())
+}
 
+func cachedFieldsForType(resultType reflect.Type) *fieldsType {
 	if fields, ok := fieldsMap.Load(resultType); ok {
 		return fields.(*fieldsType)
 	}
@@ -1112,6 +1177,7 @@ func makeStructFields(rootType reflect.Type) *fieldsType {
 			fieldType := field.Type
 			unwrappedFieldType := unwrapPtrType(fieldType)
 			var dispatch fieldDispatch
+			var structFields *fieldsType
 			switch {
 			case mayImplementUnmarshaler(unwrappedFieldType) ||
 				unwrappedFieldType.Kind() == reflect.Interface:
@@ -1120,14 +1186,18 @@ func makeStructFields(rootType reflect.Type) *fieldsType {
 				dispatch = dispatchFast
 			default:
 				dispatch = dispatchPlain
+				if fieldType.Kind() == reflect.Struct && fieldType != bigIntType {
+					structFields = cachedFieldsForType(fieldType)
+				}
 			}
 			allFields = append(allFields, fieldInfo{
-				index:     fieldIndex, // Will be reindexed later for optimization
-				name:      fieldName,
-				hasTag:    hasTag,
-				depth:     entry.depth,
-				fieldType: fieldType,
-				dispatch:  dispatch,
+				index:        fieldIndex, // Will be reindexed later for optimization
+				name:         fieldName,
+				hasTag:       hasTag,
+				depth:        entry.depth,
+				fieldType:    fieldType,
+				structFields: structFields,
+				dispatch:     dispatch,
 			})
 		}
 	}

--- a/internal/decoder/reflection.go
+++ b/internal/decoder/reflection.go
@@ -917,19 +917,29 @@ func (d *ReflectionDecoder) decodeStructWithFields(
 			offset, err = d.decodeValueSkipUnmarshaler(offset, fieldValue, depth)
 		case dispatchUnmarshaler:
 			offset, err = d.decodeValue(offset, fieldValue, depth)
-		default: // dispatchPlain
-			if fieldInfo.structFields != nil {
-				var ok bool
-				offset, ok, err = d.tryDecodeStructWithFields(
-					offset,
-					fieldValue,
-					depth,
-					fieldInfo.structFields,
-				)
-				if ok {
-					break
-				}
+		case dispatchStruct:
+			var ok bool
+			offset, ok, err = d.tryDecodeStructWithFields(
+				offset,
+				fieldValue,
+				depth,
+				fieldInfo.structFields,
+			)
+			if !ok {
+				offset, err = d.decodeValueSkipUnmarshaler(offset, fieldValue, depth)
 			}
+		case dispatchPointerStruct:
+			var ok bool
+			offset, ok, err = d.tryDecodePointerStructWithFields(
+				offset,
+				fieldValue,
+				depth,
+				fieldInfo.structFields,
+			)
+			if !ok {
+				offset, err = d.decodeValueSkipUnmarshaler(offset, fieldValue, depth)
+			}
+		default: // dispatchPlain
 			offset, err = d.decodeValueSkipUnmarshaler(offset, fieldValue, depth)
 		}
 		if err != nil {
@@ -979,11 +989,125 @@ func (d *ReflectionDecoder) tryDecodeStructWithFields(
 	}
 }
 
+func (d *ReflectionDecoder) tryDecodePointerStructWithFields(
+	offset uint,
+	result addressableValue,
+	depth int,
+	fields *fieldsType,
+) (newOffset uint, ok bool, err error) {
+	typeNum, size, dataOffset, err := d.decodeCtrlData(offset)
+	if err != nil {
+		return 0, true, err
+	}
+
+	var pointerEndOffset uint
+	decodeDepth := depth + 1
+	switch typeNum {
+	case KindMap:
+		// Use the map control record we already decoded.
+	case KindPointer:
+		var pointer uint
+		pointer, pointerEndOffset, err = d.decodePointer(size, dataOffset)
+		if err != nil {
+			return 0, true, err
+		}
+		typeNum, size, dataOffset, err = d.decodeCtrlData(pointer)
+		if err != nil {
+			return 0, true, err
+		}
+		if typeNum == KindPointer {
+			return 0, true, mmdberrors.NewInvalidDatabaseError(
+				"invalid pointer to pointer at offset %d",
+				pointer,
+			)
+		}
+		if typeNum != KindMap {
+			return 0, false, nil
+		}
+		decodeDepth = depth + 2
+	default:
+		return 0, false, nil
+	}
+
+	return d.decodePointerStructWithFields(
+		size,
+		dataOffset,
+		pointerEndOffset,
+		result,
+		decodeDepth,
+		fields,
+	)
+}
+
+func (d *ReflectionDecoder) decodePointerStructWithFields(
+	size uint,
+	dataOffset uint,
+	pointerEndOffset uint,
+	result addressableValue,
+	decodeDepth int,
+	fields *fieldsType,
+) (newOffset uint, ok bool, err error) {
+	var allocated1, allocated2 reflect.Value
+	var allocatedMore []reflect.Value
+	allocatedCount := 0
+	for result.Kind() == reflect.Pointer {
+		if result.IsNil() {
+			result.Set(reflect.New(result.Type().Elem()))
+			switch allocatedCount {
+			case 0:
+				allocated1 = result.Value
+			case 1:
+				allocated2 = result.Value
+			default:
+				allocatedMore = append(allocatedMore, result.Value)
+			}
+			allocatedCount++
+		}
+		result = addressableValue{Value: result.Elem()}
+	}
+
+	if result.Kind() != reflect.Struct {
+		cleanupAllocatedPointers(allocatedCount, allocated1, allocated2, allocatedMore)
+		return 0, false, nil
+	}
+
+	newOffset, err = d.decodeStructWithFields(size, dataOffset, result, decodeDepth, fields)
+	if err != nil {
+		cleanupAllocatedPointers(allocatedCount, allocated1, allocated2, allocatedMore)
+		return 0, true, err
+	}
+	if pointerEndOffset != 0 {
+		return pointerEndOffset, true, nil
+	}
+	return newOffset, true, nil
+}
+
+func cleanupAllocatedPointers(
+	allocatedCount int,
+	allocated1, allocated2 reflect.Value,
+	allocatedMore []reflect.Value,
+) {
+	switch allocatedCount {
+	case 0:
+		// no-op
+	case 1:
+		allocated1.SetZero()
+	case 2:
+		allocated2.SetZero()
+		allocated1.SetZero()
+	default:
+		for _, pointer := range slices.Backward(allocatedMore) {
+			pointer.SetZero()
+		}
+		allocated2.SetZero()
+		allocated1.SetZero()
+	}
+}
+
 // fieldDispatch encodes the decode strategy for a struct field, computed
 // once at struct-cache build time. Encoding the three-way choice as a
-// single enum (rather than two non-orthogonal booleans) makes the
-// illegal combination "fast path AND Unmarshaler" unrepresentable —
-// previously enforced only by an `&&` in makeStructFields.
+// single enum (rather than non-orthogonal booleans) makes illegal
+// combinations like "fast path AND Unmarshaler" unrepresentable.
 type fieldDispatch uint8
 
 const (
@@ -998,6 +1122,12 @@ const (
 	// implements Unmarshaler via its pointer receiver. Goes through
 	// decodeValue, which performs the type assertion.
 	dispatchUnmarshaler
+	// dispatchStruct: field is a nested struct whose field set is
+	// precomputed and can be decoded without consulting the field cache.
+	dispatchStruct
+	// dispatchPointerStruct: field is a pointer to a nested struct whose
+	// field set is precomputed and whose pointer chain may need allocation.
+	dispatchPointerStruct
 	// dispatchPlain: everything else (structs, slices, maps, named
 	// types without Unmarshaler). Uses decodeValueSkipUnmarshaler.
 	dispatchPlain
@@ -1105,18 +1235,42 @@ func cachedFields(result reflect.Value) *fieldsType {
 }
 
 func cachedFieldsForType(resultType reflect.Type) *fieldsType {
+	return cachedFieldsForTypeWithStack(resultType, nil)
+}
+
+func cachedFieldsForTypeWithStack(
+	resultType reflect.Type,
+	stack map[reflect.Type]bool,
+) *fieldsType {
 	if fields, ok := fieldsMap.Load(resultType); ok {
 		return fields.(*fieldsType)
 	}
 
-	fields := makeStructFields(resultType)
-	fieldsMap.Store(resultType, fields)
+	if stack != nil && stack[resultType] {
+		return nil
+	}
 
-	return fields
+	nextStack := make(map[reflect.Type]bool, len(stack)+1)
+	for typ := range stack {
+		nextStack[typ] = true
+	}
+	nextStack[resultType] = true
+
+	fields := makeStructFieldsWithStack(resultType, nextStack)
+	actual, _ := fieldsMap.LoadOrStore(resultType, fields)
+
+	return actual.(*fieldsType)
 }
 
 // makeStructFields implements json/v2 style field precedence rules.
 func makeStructFields(rootType reflect.Type) *fieldsType {
+	return makeStructFieldsWithStack(rootType, map[reflect.Type]bool{rootType: true})
+}
+
+func makeStructFieldsWithStack(
+	rootType reflect.Type,
+	stack map[reflect.Type]bool,
+) *fieldsType {
 	// Breadth-first traversal to collect all fields with depth information
 
 	queue := []queueEntry{{rootType, nil, 0}}
@@ -1186,8 +1340,15 @@ func makeStructFields(rootType reflect.Type) *fieldsType {
 				dispatch = dispatchFast
 			default:
 				dispatch = dispatchPlain
-				if fieldType.Kind() == reflect.Struct && fieldType != bigIntType {
-					structFields = cachedFieldsForType(fieldType)
+				if unwrappedFieldType.Kind() == reflect.Struct &&
+					unwrappedFieldType != bigIntType &&
+					!stack[unwrappedFieldType] {
+					structFields = cachedFieldsForTypeWithStack(unwrappedFieldType, stack)
+					if fieldType.Kind() == reflect.Pointer {
+						dispatch = dispatchPointerStruct
+					} else {
+						dispatch = dispatchStruct
+					}
 				}
 			}
 			allFields = append(allFields, fieldInfo{


### PR DESCRIPTION
- **Reject pointer-to-pointer chains in decoder**
- **Skip pointer values without decoding targets**
- **Reuse cached fields for nested structs**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pointer handling now skips pointer tokens safely and consistently rejects pointer-to-pointer chains to avoid following invalid targets.

* **Performance**
  * Faster struct decoding via per-structure cached field plans and optimized nested-type dispatch.

* **Refactor**
  * Offset resolution simplified to resolve at most one pointer, reducing complex pointer-chasing.

* **Tests**
  * Added tests for pointer-skip behavior, pointer-to-pointer detection, and struct-field caching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->