### PR TITLE
Fix release-blocking decoder and reader edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   iteration early can continue decoding from the correct next value.
 - Fixed an oversized data-pointer bounds check so malformed databases return an
   offset error instead of risking a panic on 32-bit builds.
+- Fixed migration and README examples to reference the public `mmdbdata.Decoder`
+  type for custom unmarshaling.
 
 ## 2.4.0 - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 2.4.1 - TBD
+
+- Fixed `Result.Decode` and `Result.DecodePath` after `Reader.Close` so stale
+  results return closed-database errors instead of reading invalidated data.
+
 ## 2.4.0 - 2026-06-06
 
 - Reduced reflection decoding time and memory allocations. A city-lookup benchmark

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   consistently before custom `Unmarshaler` dispatch.
 - Fixed `ReadMap` and `ReadSlice` iterator cleanup so callers that stop
   iteration early can continue decoding from the correct next value.
+- Fixed an oversized data-pointer bounds check so malformed databases return an
+  offset error instead of risking a panic on 32-bit builds.
 
 ## 2.4.0 - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Fixed `Result.Decode` and `Result.DecodePath` after `Reader.Close` so stale
   results return closed-database errors instead of reading invalidated data.
+- Fixed `Networks` and `NetworksWithin` with `SkipEmptyValues` so malformed
+  pointer cycles return an error instead of looping indefinitely.
 
 ## 2.4.0 - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   pointer cycles return an error instead of looping indefinitely.
 - Fixed top-level `Decode` validation so nil and non-pointer values are rejected
   consistently before custom `Unmarshaler` dispatch.
+- Fixed `ReadMap` and `ReadSlice` iterator cleanup so callers that stop
+  iteration early can continue decoding from the correct next value.
 
 ## 2.4.0 - 2026-06-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   results return closed-database errors instead of reading invalidated data.
 - Fixed `Networks` and `NetworksWithin` with `SkipEmptyValues` so malformed
   pointer cycles return an error instead of looping indefinitely.
+- Fixed top-level `Decode` validation so nil and non-pointer values are rejected
+  consistently before custom `Unmarshaler` dispatch.
 
 ## 2.4.0 - 2026-06-06
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -23,9 +23,10 @@
 
 ## Manual decoding improvements
 
-- Custom types can implement `UnmarshalMaxMindDB(d *maxminddb.Decoder) error`
-  to skip reflection and zero allocations for hot paths.
-- `maxminddb.Decoder` mirrors the APIs from `internal/decoder`, giving fine
+- Custom types can import `github.com/oschwald/maxminddb-golang/v2/mmdbdata`
+  and implement `UnmarshalMaxMindDB(d *mmdbdata.Decoder) error` to skip
+  reflection and zero allocations for hot paths.
+- `mmdbdata.Decoder` mirrors the APIs from `internal/decoder`, giving fine
   grained access to the underlying data section.
 - `DecodePath` works on the result object, supporting nested lookups without
   decoding entire records.

--- a/README.md
+++ b/README.md
@@ -112,13 +112,15 @@ err = db.Lookup(ip).Decode(&city)
 
 ### High-Performance Custom Unmarshaling
 
+Import `github.com/oschwald/maxminddb-golang/v2/mmdbdata` for the decoder type.
+
 ```go
 type FastCity struct {
 	CountryISO string
 	CityName   string
 }
 
-func (c *FastCity) UnmarshalMaxMindDB(d *maxminddb.Decoder) error {
+func (c *FastCity) UnmarshalMaxMindDB(d *mmdbdata.Decoder) error {
 	mapIter, size, err := d.ReadMap()
 	if err != nil {
 		return err

--- a/README.md
+++ b/README.md
@@ -222,8 +222,9 @@ regardless of the data provider.
 
 ## Performance Tips
 
-1. **Reuse Reader instances**: The `Reader` is thread-safe and should be reused
-   across goroutines
+1. **Reuse Reader instances**: Lookups, decoding, and iteration are safe to run
+   concurrently. `Close` invalidates outstanding results and should run after
+   readers are done.
 2. **Use specific structs**: Only decode the fields you need rather than using
    `any`
 3. **Implement Unmarshaler**: For high-throughput applications, implement

--- a/internal/decoder/decoder.go
+++ b/internal/decoder/decoder.go
@@ -227,7 +227,7 @@ func (d *Decoder) ReadMap() (iter.Seq2[[]byte, error], uint, error) {
 	iterator := func(yield func([]byte, error) bool) {
 		currentOffset := offset
 
-		for range size {
+		for i := range size {
 			key, keyEndOffset, err := d.d.decodeKey(currentOffset)
 			if err != nil {
 				yield(nil, d.wrapErrorAtOffset(err, currentOffset))
@@ -239,6 +239,7 @@ func (d *Decoder) ReadMap() (iter.Seq2[[]byte, error], uint, error) {
 
 			ok := yield(key, nil)
 			if !ok {
+				d.finishMapAfterStop(keyEndOffset, size-i-1)
 				return
 			}
 
@@ -277,14 +278,7 @@ func (d *Decoder) ReadSlice() (iter.Seq[error], uint, error) {
 
 			ok := yield(nil)
 			if !ok {
-				// Skip the unvisited elements
-				remaining := size - i - 1
-				if remaining > 0 {
-					endOffset, err := d.d.nextValueOffset(currentOffset, remaining)
-					if err == nil {
-						d.reset(endOffset)
-					}
-				}
+				d.finishSliceAfterStop(currentOffset, size-i)
 				return
 			}
 
@@ -355,6 +349,48 @@ func (d *Decoder) Offset() uint {
 		return d.offset
 	}
 	return pointer
+}
+
+func (d *Decoder) finishMapAfterStop(keyEndOffset, remainingPairs uint) {
+	valueEndOffset, err := d.valueEndOffsetAfterYield(keyEndOffset)
+	if err != nil {
+		return
+	}
+
+	remainingValues := remainingPairs * 2
+	if remainingValues == 0 {
+		d.reset(valueEndOffset)
+		return
+	}
+
+	endOffset, err := d.d.nextValueOffset(valueEndOffset, remainingValues)
+	if err == nil {
+		d.reset(endOffset)
+	}
+}
+
+func (d *Decoder) finishSliceAfterStop(currentOffset, remainingValues uint) {
+	endOffset := currentOffset
+	if d.hasNextOffset {
+		endOffset = d.nextOffset
+		remainingValues--
+	}
+	if remainingValues == 0 {
+		d.reset(endOffset)
+		return
+	}
+
+	endOffset, err := d.d.nextValueOffset(endOffset, remainingValues)
+	if err == nil {
+		d.reset(endOffset)
+	}
+}
+
+func (d *Decoder) valueEndOffsetAfterYield(valueOffset uint) (uint, error) {
+	if d.hasNextOffset {
+		return d.nextOffset, nil
+	}
+	return d.d.nextValueOffset(valueOffset, 1)
 }
 
 func (d *Decoder) reset(offset uint) {

--- a/internal/decoder/decoder_test.go
+++ b/internal/decoder/decoder_test.go
@@ -169,6 +169,64 @@ func TestDecodeMap(t *testing.T) {
 	}
 }
 
+func TestReadMapEarlyBreakAfterValueAdvancesPastMap(t *testing.T) {
+	data := []byte{
+		0xe2, // map size 2
+		0x41, 'a',
+		0x43, 'o', 'n', 'e',
+		0x41, 'b',
+		0xe1, // remaining value is a nested map
+		0x41, 'c',
+		0x43, 't', 'w', 'o',
+		0x44, 'd', 'o', 'n', 'e',
+	}
+
+	decoder := NewDecoder(NewDataDecoder(data), 0)
+	mapIter, _, err := decoder.ReadMap()
+	require.NoError(t, err)
+
+	for key, iterErr := range mapIter {
+		require.NoError(t, iterErr)
+		require.Equal(t, "a", string(key))
+
+		value, err := decoder.ReadString()
+		require.NoError(t, err)
+		require.Equal(t, "one", value)
+		break
+	}
+
+	value, err := decoder.ReadString()
+	require.NoError(t, err)
+	require.Equal(t, "done", value)
+}
+
+func TestReadMapEarlyBreakBeforeValueAdvancesPastMap(t *testing.T) {
+	data := []byte{
+		0xe2, // map size 2
+		0x41, 'a',
+		0xe1, // current value is a nested map
+		0x41, 'c',
+		0x43, 't', 'w', 'o',
+		0x41, 'b',
+		0x43, 'o', 'n', 'e',
+		0x44, 'd', 'o', 'n', 'e',
+	}
+
+	decoder := NewDecoder(NewDataDecoder(data), 0)
+	mapIter, _, err := decoder.ReadMap()
+	require.NoError(t, err)
+
+	for key, iterErr := range mapIter {
+		require.NoError(t, iterErr)
+		require.Equal(t, "a", string(key))
+		break
+	}
+
+	value, err := decoder.ReadString()
+	require.NoError(t, err)
+	require.Equal(t, "done", value)
+}
+
 func TestDecodeSlice(t *testing.T) {
 	tests := map[string][]any{
 		"0004":                 {}, // [cite: 55]
@@ -198,6 +256,58 @@ func TestDecodeSlice(t *testing.T) {
 			require.True(t, decoder.hasNextOffset || decoder.offset > 0, "Offset was not advanced")
 		})
 	}
+}
+
+func TestReadSliceEarlyBreakAfterValueAdvancesPastSlice(t *testing.T) {
+	data := []byte{
+		0x02, 0x04, // slice size 2
+		0x43, 'o', 'n', 'e',
+		0xe1, // remaining value is a nested map
+		0x41, 'c',
+		0x43, 't', 'w', 'o',
+		0x44, 'd', 'o', 'n', 'e',
+	}
+
+	decoder := NewDecoder(NewDataDecoder(data), 0)
+	sliceIter, _, err := decoder.ReadSlice()
+	require.NoError(t, err)
+
+	for iterErr := range sliceIter {
+		require.NoError(t, iterErr)
+
+		value, err := decoder.ReadString()
+		require.NoError(t, err)
+		require.Equal(t, "one", value)
+		break
+	}
+
+	value, err := decoder.ReadString()
+	require.NoError(t, err)
+	require.Equal(t, "done", value)
+}
+
+func TestReadSliceEarlyBreakBeforeValueAdvancesPastSlice(t *testing.T) {
+	data := []byte{
+		0x02, 0x04, // slice size 2
+		0xe1, // current value is a nested map
+		0x41, 'c',
+		0x43, 't', 'w', 'o',
+		0x43, 'o', 'n', 'e',
+		0x44, 'd', 'o', 'n', 'e',
+	}
+
+	decoder := NewDecoder(NewDataDecoder(data), 0)
+	sliceIter, _, err := decoder.ReadSlice()
+	require.NoError(t, err)
+
+	for iterErr := range sliceIter {
+		require.NoError(t, iterErr)
+		break
+	}
+
+	value, err := decoder.ReadString()
+	require.NoError(t, err)
+	require.Equal(t, "done", value)
 }
 
 func TestDecodeString(t *testing.T) {

--- a/internal/decoder/nested_unmarshaler_test.go
+++ b/internal/decoder/nested_unmarshaler_test.go
@@ -63,6 +63,65 @@ func TestNestedUnmarshaler(t *testing.T) {
 	})
 }
 
+type topLevelValidationUnmarshaler struct {
+	Value string
+}
+
+func (topLevelValidationUnmarshaler) UnmarshalMaxMindDB(*Decoder) error {
+	panic("non-pointer top-level unmarshaler should not be called")
+}
+
+type topLevelPointerUnmarshaler struct {
+	Value string
+}
+
+func (u *topLevelPointerUnmarshaler) UnmarshalMaxMindDB(d *Decoder) error {
+	value, err := d.ReadString()
+	if err != nil {
+		return err
+	}
+	u.Value = "custom:" + value
+	return nil
+}
+
+func TestTopLevelUnmarshalerRequiresNonNilPointer(t *testing.T) {
+	d := New([]byte{0x43, 'F', 'o', 'o'})
+
+	var nilPointer *topLevelPointerUnmarshaler
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{
+			name:  "nil interface",
+			value: nil,
+		},
+		{
+			name:  "non-pointer value receiver unmarshaler",
+			value: topLevelValidationUnmarshaler{},
+		},
+		{
+			name:  "typed nil pointer unmarshaler",
+			value: nilPointer,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := d.Decode(0, tc.value)
+			require.EqualError(t, err, "result param must be a pointer")
+		})
+	}
+}
+
+func TestTopLevelUnmarshalerStillUsesValidPointer(t *testing.T) {
+	d := New([]byte{0x43, 'F', 'o', 'o'})
+
+	var result topLevelPointerUnmarshaler
+	require.NoError(t, d.Decode(0, &result))
+	require.Equal(t, "custom:Foo", result.Value)
+}
+
 // testInnerPointer with UnmarshalMaxMindDB for pointer test.
 type testInnerPointer struct {
 	Value  string

--- a/internal/decoder/reflection.go
+++ b/internal/decoder/reflection.go
@@ -37,6 +37,7 @@ func New(buffer []byte) ReflectionDecoder {
 // Returns true if the value is a map or array with size 0.
 func (d *ReflectionDecoder) IsEmptyValueAt(offset uint) (bool, error) {
 	dataOffset := offset
+	followedPointers := 0
 	for {
 		kindNum, size, newOffset, err := d.decodeCtrlData(dataOffset)
 		if err != nil {
@@ -44,6 +45,12 @@ func (d *ReflectionDecoder) IsEmptyValueAt(offset uint) (bool, error) {
 		}
 
 		if kindNum == KindPointer {
+			if followedPointers >= maximumDataStructureDepth {
+				return false, mmdberrors.NewInvalidDatabaseError(
+					"exceeded maximum data structure depth; database is likely corrupt",
+				)
+			}
+			followedPointers++
 			dataOffset, _, err = d.decodePointer(size, newOffset)
 			if err != nil {
 				return false, err

--- a/internal/decoder/reflection.go
+++ b/internal/decoder/reflection.go
@@ -66,15 +66,14 @@ func (d *ReflectionDecoder) IsEmptyValueAt(offset uint) (bool, error) {
 // Decode decodes the data value at offset and stores it in the value
 // pointed at by v.
 func (d *ReflectionDecoder) Decode(offset uint, v any) error {
-	// Check if the type implements Unmarshaler interface without reflection
-	if unmarshaler, ok := v.(Unmarshaler); ok {
-		decoder := NewDecoder(d.DataDecoder, offset)
-		return unmarshaler.UnmarshalMaxMindDB(decoder)
-	}
-
 	rv := reflect.ValueOf(v)
 	if rv.Kind() != reflect.Pointer || rv.IsNil() {
 		return errors.New("result param must be a pointer")
+	}
+
+	if unmarshaler, ok := v.(Unmarshaler); ok {
+		decoder := NewDecoder(d.DataDecoder, offset)
+		return unmarshaler.UnmarshalMaxMindDB(decoder)
 	}
 
 	_, err := d.decode(offset, rv, 0)

--- a/internal/decoder/reflection.go
+++ b/internal/decoder/reflection.go
@@ -592,7 +592,7 @@ func (d *ReflectionDecoder) unmarshalPointer(
 
 	// Check for pointer-to-pointer by looking at what we're about to decode
 	// This is done efficiently by checking the control byte at the pointer location
-	if len(d.buffer) > int(pointer) {
+	if pointer < uint(len(d.buffer)) {
 		controlByte := d.buffer[pointer]
 		if Kind(controlByte>>5) == KindPointer {
 			return 0, mmdberrors.NewInvalidDatabaseError(

--- a/internal/decoder/reflection_test.go
+++ b/internal/decoder/reflection_test.go
@@ -588,6 +588,20 @@ func TestPointers(t *testing.T) {
 	}
 }
 
+func TestOversizedPointerReturnsError(t *testing.T) {
+	d := New([]byte{
+		0x38,                   // pointer with 4-byte payload
+		0xff, 0xff, 0xff, 0xff, // offset math overflows int on 32-bit
+	})
+
+	var result any
+	var err error
+	require.NotPanics(t, func() {
+		err = d.Decode(0, &result)
+	})
+	require.ErrorContains(t, err, "unexpected end of database")
+}
+
 func testFile(file string) string {
 	return filepath.Join("..", "..", "test-data", "test-data", file)
 }

--- a/internal/decoder/reflection_test.go
+++ b/internal/decoder/reflection_test.go
@@ -187,6 +187,28 @@ func TestDecodeAllocatesTopLevelPointerTarget(t *testing.T) {
 	assert.Equal(t, "Foo", *result)
 }
 
+func TestIsEmptyValueAtFollowsPointers(t *testing.T) {
+	d := New([]byte{
+		0x20, 0x02, // pointer to offset 2
+		0xe0, // empty map
+	})
+
+	empty, err := d.IsEmptyValueAt(0)
+	require.NoError(t, err)
+	require.True(t, empty)
+}
+
+func TestIsEmptyValueAtRejectsPointerCycle(t *testing.T) {
+	d := New([]byte{
+		0x20, 0x00, // pointer to offset 0
+	})
+
+	empty, err := d.IsEmptyValueAt(0)
+	require.Error(t, err)
+	require.False(t, empty)
+	require.ErrorContains(t, err, "exceeded maximum data structure depth")
+}
+
 func TestMap(t *testing.T) {
 	maps := map[string]any{
 		"e0":                             map[string]any{},

--- a/reader.go
+++ b/reader.go
@@ -100,8 +100,8 @@
 //
 // # Thread Safety
 //
-// All Reader methods are thread-safe. The Reader can be safely shared across
-// multiple goroutines.
+// Reader lookup, decode, and iteration methods are safe to call concurrently.
+// Close must not be called concurrently with other Reader or Result methods.
 package maxminddb
 
 import (
@@ -133,8 +133,8 @@ type mmapCleanup struct {
 // Reader holds the data corresponding to the MaxMind DB file. Its only public
 // field is Metadata, which contains the metadata from the MaxMind DB file.
 //
-// All of the methods on Reader are thread-safe. The struct may be safely
-// shared across goroutines.
+// Reader lookup, decode, and iteration methods are safe to call concurrently.
+// Close must not be called concurrently with other Reader or Result methods.
 type Reader struct {
 	hasMappedFile     *atomic.Bool
 	decoder           decoder.ReflectionDecoder

--- a/reader_test.go
+++ b/reader_test.go
@@ -989,6 +989,30 @@ func TestUsingClosedDatabase(t *testing.T) {
 	assert.Equal(t, "cannot call LookupOffset on a closed database", err.Error())
 }
 
+func TestResultDecodeAfterReaderClose(t *testing.T) {
+	reader, err := Open(testFile("MaxMind-DB-test-decoder.mmdb"))
+	require.NoError(t, err)
+
+	result := reader.Lookup(netip.MustParseAddr("::1.1.1.0"))
+	require.NoError(t, result.Err())
+	require.True(t, result.Found())
+
+	offsetResult := reader.LookupOffset(result.Offset())
+
+	require.NoError(t, reader.Close())
+
+	var record any
+	require.EqualError(t, result.Decode(&record), "cannot call Decode on a closed database")
+	require.EqualError(t, offsetResult.Decode(&record), "cannot call Decode on a closed database")
+
+	var value string
+	require.EqualError(
+		t,
+		result.DecodePath(&value, "utf8_string"),
+		"cannot call DecodePath on a closed database",
+	)
+}
+
 func checkMetadata(t *testing.T, reader *Reader, ipVersion, recordSize uint) {
 	metadata := reader.Metadata
 

--- a/result.go
+++ b/result.go
@@ -1,6 +1,7 @@
 package maxminddb
 
 import (
+	"errors"
 	"math"
 	"net/netip"
 )
@@ -33,6 +34,9 @@ func (r Result) Decode(v any) error {
 	}
 	if r.offset == notFound {
 		return nil
+	}
+	if r.reader == nil || r.reader.buffer == nil {
+		return errors.New("cannot call Decode on a closed database")
 	}
 
 	return r.reader.decoder.Decode(r.offset, v)
@@ -91,6 +95,9 @@ func (r Result) DecodePath(v any, path ...any) error {
 	}
 	if r.offset == notFound {
 		return nil
+	}
+	if r.reader == nil || r.reader.buffer == nil {
+		return errors.New("cannot call DecodePath on a closed database")
 	}
 	return r.reader.decoder.DecodePath(r.offset, path, v)
 }


### PR DESCRIPTION
## Summary

- return closed-database errors for stale `Result` decode paths after `Reader.Close`
- bound empty-value pointer traversal and oversized pointer handling for malformed databases
- validate top-level `Decode` arguments before custom unmarshaler dispatch
- advance manual decoder iterators correctly after early `ReadMap`/`ReadSlice` stops
- correct custom unmarshaler docs to reference `mmdbdata.Decoder`

## Testing

- `golangci-lint run ./...`
- `go test -count=1 ./...`
- `GOARCH=386 go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `go vet ./...`
- `go test -shuffle=on -count=5 ./...`
- `go test -run '^$' -fuzz=FuzzDatabase -fuzztime=10s .`\n- `go test -run '^$' -fuzz='^FuzzDecode$' -fuzztime=10s .`\n\n## Benchmarks\n\nSequential before/after full benchmark runs were compared with `benchstat` using:\n\n- `go test -run '^$' -bench . -benchmem -count=10 ./...`\n\nResult: no regressions found. Root package geomean improved 1.07% sec/op with unchanged allocations. `internal/decoder` geomean improved 3.13% sec/op with unchanged allocations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed decoding results after a database is closed, with clear errors for follow-up lookups and decodes.
  * Improved handling of early-stopped map and slice iteration so later reads stay correct.
  * Hardened pointer and cycle handling to avoid panics and return safer errors in malformed data.
  * Tightened top-level decoding checks so invalid inputs are rejected consistently.

* **Documentation**
  * Updated examples and guidance to use the public custom-unmarshaling decoder type.
  * Clarified concurrency behavior and when it’s safe to call `Close`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->