### PR TITLE
Improve reader robustness and lookup performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Reduced opening memory by decoding metadata without a string cache and added
   `DisableStringCache` for readers that favor lower memory over repeated-decode
   allocation savings.
+- Released decoder-owned data and cache references when a reader is closed.
 
 ## 2.4.1 - 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   records.
 - Reduced allocations when recurring decoded strings share a primary cache
   slot.
+- Reduced struct decoding time by using compact field-name fingerprints before
+  falling back to full string hashing.
 - Rejected impossible or malformed large container sizes before allocating
   destination maps and slices, while reducing preflight overhead for common
   strings and booleans and avoiding preflight when caller-provided slice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   `DisableStringCache` for readers that favor lower memory over repeated-decode
   allocation savings.
 - Released decoder-owned data and cache references when a reader is closed.
+- Rejected invalid `netip.Addr` lookup values.
 
 ## 2.4.1 - 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Reduced IPv4 and IPv6 lookup time for databases with 28-bit search-tree
   records.
+- Reduced allocations when recurring decoded strings share a primary cache
+  slot.
 - Rejected impossible or malformed large container sizes before allocating
   destination maps and slices, while reducing preflight overhead for common
   strings and booleans and avoiding preflight when caller-provided slice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - Rejected invalid `netip.Addr` lookup values.
 - Made verification reject invalid UTF-8 strings and made empty-value filtering
   reject pointer-to-pointer records consistently with other decoder paths.
+- Corrected cold-cache and concurrent-lookup benchmarks so they measure steady
+  cache misses and lookup work rather than warm caches and goroutine setup.
 
 ## 2.4.1 - 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   destination maps and slices, while reducing preflight overhead for common
   strings and booleans and avoiding preflight when caller-provided slice
   capacity already prevents an allocation.
+- Kept readers reachable through memory-mapped lookup, decode, and iteration
+  operations so runtime cleanup cannot unmap active data.
 
 ## 2.4.1 - 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   capacity already prevents an allocation.
 - Kept readers reachable through memory-mapped lookup, decode, and iteration
   operations so runtime cleanup cannot unmap active data.
+- Reduced opening memory by decoding metadata without a string cache and added
+  `DisableStringCache` for readers that favor lower memory over repeated-decode
+  allocation savings.
 
 ## 2.4.1 - 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   allocation savings.
 - Released decoder-owned data and cache references when a reader is closed.
 - Rejected invalid `netip.Addr` lookup values.
+- Made verification reject invalid UTF-8 strings and made empty-value filtering
+  reject pointer-to-pointer records consistently with other decoder paths.
 
 ## 2.4.1 - 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes
 
+## Unreleased
+
+- Rejected impossible or malformed large container sizes before allocating
+  destination maps and slices, while reducing preflight overhead for common
+  strings and booleans and avoiding preflight when caller-provided slice
+  capacity already prevents an allocation.
+
 ## 2.4.1 - 2026-06-28
 
 - Fixed `Result.Decode` and `Result.DecodePath` after `Reader.Close` so stale

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Reduced IPv4 and IPv6 lookup time for databases with 28-bit search-tree
+  records.
 - Rejected impossible or malformed large container sizes before allocating
   destination maps and slices, while reducing preflight overhead for common
   strings and booleans and avoiding preflight when caller-provided slice

--- a/internal/decoder/data_decoder.go
+++ b/internal/decoder/data_decoder.go
@@ -539,6 +539,7 @@ func (d *DataDecoder) decodeKey(offset uint) ([]byte, uint, error) {
 // the one at the offset passed in. The size bits have different meanings for
 // different data types.
 func (d *DataDecoder) nextValueOffset(offset, numberToSkip uint) (uint, error) {
+	bufferLen := uint(len(d.buffer))
 	for numberToSkip > 0 {
 		kindNum, size, newOffset, err := d.decodeCtrlData(offset)
 		if err != nil {
@@ -557,12 +558,21 @@ func (d *DataDecoder) nextValueOffset(offset, numberToSkip uint) (uint, error) {
 			}
 			newOffset = ptrEndOffset
 		case KindMap:
+			if size > (^uint(0)-numberToSkip)/2 {
+				return 0, mmdberrors.NewInvalidDatabaseError("container size overflow")
+			}
 			numberToSkip += 2 * size
 		case KindSlice:
+			if size > ^uint(0)-numberToSkip {
+				return 0, mmdberrors.NewInvalidDatabaseError("container size overflow")
+			}
 			numberToSkip += size
 		case KindBool:
 			// size encodes the boolean; nothing else to skip
 		default:
+			if !hasBufferRange(bufferLen, newOffset, size) {
+				return 0, mmdberrors.NewOffsetError()
+			}
 			newOffset += size
 		}
 
@@ -570,6 +580,10 @@ func (d *DataDecoder) nextValueOffset(offset, numberToSkip uint) (uint, error) {
 		numberToSkip--
 	}
 	return offset, nil
+}
+
+func hasBufferRange(bufferLen, offset, size uint) bool {
+	return size <= bufferLen && offset <= bufferLen-size
 }
 
 func decodeBool(size, offset uint) (bool, uint) {

--- a/internal/decoder/data_decoder.go
+++ b/internal/decoder/data_decoder.go
@@ -125,6 +125,13 @@ func NewDataDecoder(buffer []byte) DataDecoder {
 	}
 }
 
+// NewDataDecoderWithoutStringCache creates a DataDecoder that does not retain
+// decoded strings. It is intended for one-shot decoding where cache setup
+// would cost more than repeated string allocation.
+func NewDataDecoderWithoutStringCache(buffer []byte) DataDecoder {
+	return DataDecoder{buffer: buffer}
+}
+
 // getBuffer returns the underlying buffer for direct access.
 func (d *DataDecoder) getBuffer() []byte {
 	return d.buffer
@@ -298,6 +305,9 @@ func (d *DataDecoder) decodeString(size, offset uint) (string, uint, error) {
 	}
 
 	newOffset := offset + size
+	if d.stringCache == nil {
+		return string(d.buffer[offset:newOffset]), newOffset, nil
+	}
 	value := d.stringCache.internAt(offset, size, d.buffer)
 	return value, newOffset, nil
 }

--- a/internal/decoder/performance_test.go
+++ b/internal/decoder/performance_test.go
@@ -2,7 +2,9 @@ package decoder
 
 import (
 	"encoding/hex"
+	"fmt"
 	"reflect"
+	"strconv"
 	"testing"
 )
 
@@ -89,5 +91,56 @@ func BenchmarkFieldLookup(b *testing.B) {
 				b.Fatalf("Field %s not found", name)
 			}
 		}
+	}
+}
+
+func BenchmarkLargeSliceDecoding(b *testing.B) {
+	for _, size := range []int{1023, 1024} {
+		data := make([]byte, 0, 4+size*2)
+		data = append(data, 0x1e, 0x04, byte((size-285)>>8), byte(size-285))
+		for range size {
+			data = append(data, 0x00, 0x07) // false
+		}
+		d := NewWithoutStringCache(data)
+
+		b.Run(fmt.Sprintf("%d/new", size), func(b *testing.B) {
+			for b.Loop() {
+				var result []bool
+				if err := d.Decode(0, &result); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("%d/reused", size), func(b *testing.B) {
+			result := make([]bool, 0, size)
+			for b.Loop() {
+				if err := d.Decode(0, &result); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkLargeMapDecoding(b *testing.B) {
+	for _, size := range []int{511, 512} {
+		data := make([]byte, 0, 3+size*6)
+		data = append(data, 0xfe, byte((size-285)>>8), byte(size-285))
+		for i := range size {
+			data = append(data, 0x44)
+			data = append(data, fmt.Sprintf("%04x", i)...)
+			data = append(data, 0x00, 0x07) // false
+		}
+		d := NewWithoutStringCache(data)
+
+		b.Run(strconv.Itoa(size), func(b *testing.B) {
+			for b.Loop() {
+				var result map[string]bool
+				if err := d.Decode(0, &result); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
 	}
 }

--- a/internal/decoder/reflection.go
+++ b/internal/decoder/reflection.go
@@ -33,6 +33,14 @@ func New(buffer []byte) ReflectionDecoder {
 	}
 }
 
+// NewWithoutStringCache creates a ReflectionDecoder without a string cache.
+// It is intended for one-shot decoding such as database metadata parsing.
+func NewWithoutStringCache(buffer []byte) ReflectionDecoder {
+	return ReflectionDecoder{
+		DataDecoder: NewDataDecoderWithoutStringCache(buffer),
+	}
+}
+
 // IsEmptyValueAt checks if the value at the given offset is an empty map or array.
 // Returns true if the value is a map or array with size 0.
 func (d *ReflectionDecoder) IsEmptyValueAt(offset uint) (bool, error) {

--- a/internal/decoder/reflection.go
+++ b/internal/decoder/reflection.go
@@ -1080,7 +1080,11 @@ func (d *ReflectionDecoder) decodeStructWithFields(
 		}
 		// The string() does not create a copy due to this compiler
 		// optimization: https://github.com/golang/go/issues/3512
-		fieldInfo, ok := fields.namedFields[string(key)]
+		fingerprint := fieldKeyFingerprint(key)
+		fieldInfo, ok := fields.fieldForFingerprint(fingerprint)
+		if ok && (fieldInfo == nil || fieldInfo.name != string(key)) {
+			fieldInfo, ok = fields.namedFields[string(key)]
+		}
 		if !ok {
 			offset, err = d.nextValueOffset(offset, 1)
 			if err != nil {
@@ -1368,8 +1372,69 @@ type fieldInfo struct {
 }
 
 type fieldsType struct {
-	namedFields   map[string]*fieldInfo // Map from field name to field info
-	validationErr error
+	validationErr     error
+	namedFields       map[string]*fieldInfo // Map from field name to field info
+	fingerprintFields []fingerprintField
+}
+
+type fingerprintField struct {
+	field       *fieldInfo
+	fingerprint uint64
+}
+
+func (fs *fieldsType) fieldForFingerprint(fingerprint uint64) (*fieldInfo, bool) {
+	mask := uint64(len(fs.fingerprintFields) - 1)
+	index := (fingerprint ^ (fingerprint >> 16) ^ (fingerprint >> 32)) & mask
+	for {
+		entry := fs.fingerprintFields[index]
+		if entry.fingerprint == 0 {
+			return nil, false
+		}
+		if entry.fingerprint == fingerprint {
+			return entry.field, true
+		}
+		index = (index + 1) & mask
+	}
+}
+
+func fieldKeyFingerprint(key []byte) uint64 {
+	// Length plus the first and last two bytes distinguish ordinary MMDB
+	// field names cheaply. Collisions fall back to the full string map.
+	n := len(key)
+	fingerprint := uint64(n) << 32
+	if n > 0 {
+		fingerprint |= uint64(key[0]) << 24
+		fingerprint |= uint64(key[n-1]) << 16
+	}
+	if n > 1 {
+		fingerprint |= uint64(key[1]) << 8
+		fingerprint |= uint64(key[n-2])
+	}
+	return fingerprint
+}
+
+func makeFingerprintFields(namedFields map[string]*fieldInfo) []fingerprintField {
+	tableSize := 1
+	for tableSize < len(namedFields)*2 {
+		tableSize *= 2
+	}
+	fingerprintFields := make([]fingerprintField, tableSize)
+	mask := uint64(tableSize - 1)
+	for _, field := range namedFields {
+		fingerprint := fieldKeyFingerprint([]byte(field.name))
+		index := (fingerprint ^ (fingerprint >> 16) ^ (fingerprint >> 32)) & mask
+		for fingerprintFields[index].fingerprint != 0 &&
+			fingerprintFields[index].fingerprint != fingerprint {
+			index = (index + 1) & mask
+		}
+		entry := &fingerprintFields[index]
+		if entry.fingerprint != 0 {
+			entry.field = nil
+			continue
+		}
+		*entry = fingerprintField{fingerprint: fingerprint, field: field}
+	}
+	return fingerprintFields
 }
 
 type queueEntry struct {
@@ -1643,8 +1708,9 @@ func makeStructFieldsWithStack(
 	}
 
 	fields := &fieldsType{
-		namedFields:   namedFields,
-		validationErr: validationErr,
+		namedFields:       namedFields,
+		fingerprintFields: makeFingerprintFields(namedFields),
+		validationErr:     validationErr,
 	}
 
 	// Reindex all fields for optimized access

--- a/internal/decoder/reflection.go
+++ b/internal/decoder/reflection.go
@@ -53,9 +53,10 @@ func (d *ReflectionDecoder) IsEmptyValueAt(offset uint) (bool, error) {
 		}
 
 		if kindNum == KindPointer {
-			if followedPointers >= maximumDataStructureDepth {
+			if followedPointers > 0 {
 				return false, mmdberrors.NewInvalidDatabaseError(
-					"exceeded maximum data structure depth; database is likely corrupt",
+					"invalid pointer to pointer at offset %d",
+					dataOffset,
 				)
 			}
 			followedPointers++

--- a/internal/decoder/reflection.go
+++ b/internal/decoder/reflection.go
@@ -564,9 +564,15 @@ func (d *ReflectionDecoder) unmarshalMap(
 	case reflect.Struct:
 		return d.decodeStruct(size, offset, result, depth)
 	case reflect.Map:
+		if err := d.validateContainerSize(KindMap, size, offset, depth); err != nil {
+			return 0, err
+		}
 		return d.decodeMap(size, offset, result, depth)
 	case reflect.Interface:
 		if result.NumMethod() == 0 {
+			if err := d.validateContainerSize(KindMap, size, offset, depth); err != nil {
+				return 0, err
+			}
 			// Create map directly without makeAddressable wrapper
 			mapVal := reflect.ValueOf(make(map[string]any, size))
 			rv := addressableValue{Value: mapVal}
@@ -614,9 +620,17 @@ func (d *ReflectionDecoder) unmarshalSlice(
 ) (uint, error) {
 	switch result.Kind() {
 	case reflect.Slice:
+		if (result.IsNil() || result.Cap() < int(size)) && size > 0 {
+			if err := d.validateContainerSize(KindSlice, size, offset, depth); err != nil {
+				return 0, err
+			}
+		}
 		return d.decodeSlice(size, offset, result, depth)
 	case reflect.Interface:
 		if result.NumMethod() == 0 {
+			if err := d.validateContainerSize(KindSlice, size, offset, depth); err != nil {
+				return 0, err
+			}
 			a := []any{}
 			// Create slice directly without makeAddressable wrapper
 			sliceVal := reflect.ValueOf(&a).Elem()
@@ -629,6 +643,179 @@ func (d *ReflectionDecoder) unmarshalSlice(
 		// Fall through to error return
 	}
 	return 0, mmdberrors.NewUnmarshalTypeStrError("array", result.Type())
+}
+
+func (d *ReflectionDecoder) validateContainerSize(kind Kind, size, offset uint, depth int) error {
+	bufferLen := uint(len(d.buffer))
+	if offset > bufferLen {
+		return mmdberrors.NewOffsetError()
+	}
+
+	valueCount := size
+	if kind == KindMap {
+		if size > ^uint(0)/2 {
+			return mmdberrors.NewInvalidDatabaseError("container size overflow")
+		}
+		valueCount = size * 2
+	}
+
+	// Every encoded value occupies at least one byte. Reject impossible counts
+	// before using an attacker-controlled size as an allocation hint.
+	if valueCount > bufferLen-offset {
+		return mmdberrors.NewOffsetError()
+	}
+
+	// Large allocations are uncommon in MMDB records. Validate their complete
+	// encoded structure first, while keeping ordinary records single-pass.
+	const preflightValueCount = 1024
+	if valueCount >= preflightValueCount {
+		_, err := d.validateContainerContents(kind, size, offset, depth)
+		return err
+	}
+	return nil
+}
+
+//nolint:nestif // Keeping compact values inline avoids a call for every entry.
+func (d *ReflectionDecoder) validateContainerContents(
+	kind Kind,
+	size uint,
+	offset uint,
+	depth int,
+) (uint, error) {
+	bufferLen := uint(len(d.buffer))
+	for range size {
+		if kind == KindMap {
+			// Map keys are ordinarily directly encoded short strings. Validate
+			// that form inline and leave pointers and extended sizes to the
+			// complete validator below.
+			ctrlByte := byte(0)
+			if offset < bufferLen {
+				ctrlByte = d.buffer[offset]
+			}
+			keySize := uint(ctrlByte & 0x1f)
+			if offset >= bufferLen || Kind(ctrlByte>>5) != KindString || keySize >= 29 ||
+				!hasBufferRange(bufferLen, offset+1, keySize) {
+				var err error
+				offset, err = d.validateValueForAllocation(offset, depth, true)
+				if err != nil {
+					return 0, err
+				}
+			} else {
+				offset += 1 + keySize
+			}
+		}
+
+		// Booleans have a fixed two-byte encoding and no payload. They are
+		// common in large generated containers.
+		if offset+1 < bufferLen && d.buffer[offset] <= 1 && d.buffer[offset+1] == 7 {
+			offset += 2
+			continue
+		}
+
+		var err error
+		offset, err = d.validateValueForAllocation(offset, depth, false)
+		if err != nil {
+			return 0, err
+		}
+	}
+	return offset, nil
+}
+
+func (d *ReflectionDecoder) validateValueForAllocation(
+	offset uint,
+	depth int,
+	requireString bool,
+) (uint, error) {
+	if depth > maximumDataStructureDepth {
+		return 0, mmdberrors.NewInvalidDatabaseError(
+			"exceeded maximum data structure depth; database is likely corrupt",
+		)
+	}
+
+	kind, size, dataOffset, err := d.decodeCtrlData(offset)
+	if err != nil {
+		return 0, err
+	}
+	if kind == KindPointer {
+		pointer, nextOffset, err := d.decodePointer(size, dataOffset)
+		if err != nil {
+			return 0, err
+		}
+		targetKind, _, _, err := d.decodeCtrlData(pointer)
+		if err != nil {
+			return 0, err
+		}
+		if targetKind == KindPointer {
+			return 0, mmdberrors.NewInvalidDatabaseError(
+				"invalid pointer to pointer at offset %d",
+				pointer,
+			)
+		}
+		_, err = d.validateValueForAllocation(pointer, depth+1, requireString)
+		return nextOffset, err
+	}
+
+	if requireString && kind != KindString {
+		return 0, mmdberrors.NewInvalidDatabaseError(
+			"unexpected map key type: %s",
+			kind.String(),
+		)
+	}
+
+	bufferLen := uint(len(d.buffer))
+	switch kind {
+	case KindString, KindBytes:
+		if !hasBufferRange(bufferLen, dataOffset, size) {
+			return 0, mmdberrors.NewOffsetError()
+		}
+		return dataOffset + size, nil
+	case KindFloat64:
+		return validateFixedSize(kind, size, dataOffset, bufferLen, 8)
+	case KindFloat32:
+		return validateFixedSize(kind, size, dataOffset, bufferLen, 4)
+	case KindInt32, KindUint32:
+		return validateMaximumSize(kind, size, dataOffset, bufferLen, 4)
+	case KindUint16:
+		return validateMaximumSize(kind, size, dataOffset, bufferLen, 2)
+	case KindUint64:
+		return validateMaximumSize(kind, size, dataOffset, bufferLen, 8)
+	case KindUint128:
+		return validateMaximumSize(kind, size, dataOffset, bufferLen, 16)
+	case KindBool:
+		if size > 1 {
+			return 0, mmdberrors.NewInvalidDatabaseError("invalid bool size: %d", size)
+		}
+		return dataOffset, nil
+	case KindMap, KindSlice:
+		return d.validateContainerContents(kind, size, dataOffset, depth+1)
+	default:
+		return 0, mmdberrors.NewInvalidDatabaseError("unknown type: %d", kind)
+	}
+}
+
+func validateFixedSize(kind Kind, size, offset, bufferLen, expected uint) (uint, error) {
+	if size != expected {
+		return 0, mmdberrors.NewInvalidDatabaseError(
+			"invalid %s size: %d",
+			kind.String(),
+			size,
+		)
+	}
+	return validateMaximumSize(kind, size, offset, bufferLen, expected)
+}
+
+func validateMaximumSize(kind Kind, size, offset, bufferLen, maximum uint) (uint, error) {
+	if size > maximum {
+		return 0, mmdberrors.NewInvalidDatabaseError(
+			"invalid %s size: %d",
+			kind.String(),
+			size,
+		)
+	}
+	if !hasBufferRange(bufferLen, offset, size) {
+		return 0, mmdberrors.NewOffsetError()
+	}
+	return offset + size, nil
 }
 
 func (d *ReflectionDecoder) unmarshalString(

--- a/internal/decoder/reflection_test.go
+++ b/internal/decoder/reflection_test.go
@@ -299,6 +299,38 @@ func TestMap(t *testing.T) {
 	validateDecoding(t, maps)
 }
 
+func TestDecodeStructFieldFingerprintCollisions(t *testing.T) {
+	type resultType struct {
+		First  string `maxminddb:"abXXyz"`
+		Second string `maxminddb:"abYYyz"`
+	}
+
+	firstKey := []byte("abXXyz")
+	secondKey := []byte("abYYyz")
+	unknownKey := []byte("abZZyz")
+	require.Equal(t, fieldKeyFingerprint(firstKey), fieldKeyFingerprint(secondKey))
+	require.Equal(t, fieldKeyFingerprint(firstKey), fieldKeyFingerprint(unknownKey))
+
+	capacity := 1 + 6 + len(firstKey) + len(secondKey) + len(unknownKey) +
+		len("one") + len("two") + len("ignored")
+	data := make([]byte, 1, capacity)
+	data[0] = 0xe3 // map with three entries
+	data = append(data, 0x46)
+	data = append(data, firstKey...)
+	data = append(data, 0x43, 'o', 'n', 'e')
+	data = append(data, 0x46)
+	data = append(data, secondKey...)
+	data = append(data, 0x43, 't', 'w', 'o')
+	data = append(data, 0x46)
+	data = append(data, unknownKey...)
+	data = append(data, 0x47, 'i', 'g', 'n', 'o', 'r', 'e', 'd')
+
+	var result resultType
+	d := NewWithoutStringCache(data)
+	require.NoError(t, d.Decode(0, &result))
+	require.Equal(t, resultType{First: "one", Second: "two"}, result)
+}
+
 func TestSlice(t *testing.T) {
 	slice := map[string]any{
 		"0004":                 []any{},

--- a/internal/decoder/reflection_test.go
+++ b/internal/decoder/reflection_test.go
@@ -209,6 +209,81 @@ func TestIsEmptyValueAtRejectsPointerCycle(t *testing.T) {
 	require.ErrorContains(t, err, "exceeded maximum data structure depth")
 }
 
+func TestDecodeRejectsOversizedContainersBeforeAllocation(t *testing.T) {
+	invalidMapKeys := make([]byte, 0, 3+512*3)
+	invalidMapKeys = append(invalidMapKeys, 0xfe, 0x00, 0xe3) // map with 512 entries
+	for range 512 {
+		invalidMapKeys = append(invalidMapKeys,
+			0x00, 0x07, // false boolean key
+			0xe0, // empty map value
+		)
+	}
+
+	invalidFloatSizes := make([]byte, 0, 4+1024)
+	invalidFloatSizes = append(invalidFloatSizes, 0x1e, 0x04, 0x02, 0xe3) // slice with 1024 entries
+	for range 1024 {
+		invalidFloatSizes = append(invalidFloatSizes, 0x60) // float64 with size 0
+	}
+
+	invalidPointerTarget := make([]byte, 0, 4+5+1023)
+	invalidPointerTarget = append(invalidPointerTarget,
+		0x1e, 0x04, 0x02, 0xe3, // slice with 1024 entries
+		0x38, 0xff, 0xff, 0xff, 0xff, // pointer outside the buffer
+	)
+	for range 1023 {
+		invalidPointerTarget = append(invalidPointerTarget, 0xe0)
+	}
+
+	tests := []struct {
+		name        string
+		data        []byte
+		out         any
+		expectedErr string
+	}{
+		{
+			name:        "impossible map size",
+			data:        []byte{0xff, 0xff, 0xff, 0xff},
+			out:         new(map[string]any),
+			expectedErr: "unexpected end of database",
+		},
+		{
+			name:        "impossible slice size",
+			data:        []byte{0x1f, 0x04, 0xff, 0xff, 0xff},
+			out:         new([]any),
+			expectedErr: "unexpected end of database",
+		},
+		{
+			name:        "invalid map key types",
+			data:        invalidMapKeys,
+			out:         new(map[string]any),
+			expectedErr: "unexpected map key type",
+		},
+		{
+			name:        "invalid scalar sizes",
+			data:        invalidFloatSizes,
+			out:         new([]any),
+			expectedErr: "invalid Float64 size",
+		},
+		{
+			name:        "invalid pointer target",
+			data:        invalidPointerTarget,
+			out:         new([]any),
+			expectedErr: "unexpected end of database",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := NewWithoutStringCache(tt.data)
+			err := d.Decode(0, tt.out)
+			require.ErrorContains(t, err, tt.expectedErr)
+
+			value := reflect.ValueOf(tt.out).Elem()
+			require.True(t, value.IsNil(), "destination should not be allocated on invalid input")
+		})
+	}
+}
+
 func TestMap(t *testing.T) {
 	maps := map[string]any{
 		"e0":                             map[string]any{},

--- a/internal/decoder/reflection_test.go
+++ b/internal/decoder/reflection_test.go
@@ -198,7 +198,7 @@ func TestIsEmptyValueAtFollowsPointers(t *testing.T) {
 	require.True(t, empty)
 }
 
-func TestIsEmptyValueAtRejectsPointerCycle(t *testing.T) {
+func TestIsEmptyValueAtRejectsPointerToPointer(t *testing.T) {
 	d := New([]byte{
 		0x20, 0x00, // pointer to offset 0
 	})
@@ -206,7 +206,7 @@ func TestIsEmptyValueAtRejectsPointerCycle(t *testing.T) {
 	empty, err := d.IsEmptyValueAt(0)
 	require.Error(t, err)
 	require.False(t, empty)
-	require.ErrorContains(t, err, "exceeded maximum data structure depth")
+	require.ErrorContains(t, err, "invalid pointer to pointer")
 }
 
 func TestDecodeRejectsOversizedContainersBeforeAllocation(t *testing.T) {

--- a/internal/decoder/string_cache.go
+++ b/internal/decoder/string_cache.go
@@ -9,7 +9,9 @@ type cacheEntry struct {
 	offset uint
 }
 
-// stringCache holds two parallel 4096-slot arrays indexed by offset%4096.
+const stringCacheSlots = 4096
+
+// stringCache holds two parallel arrays indexed by data offset.
 // entries holds admitted strings; recentMisses records the last missing
 // offset seen at each slot so we can admit only on the second consecutive
 // miss for the same offset (see internAt).
@@ -18,8 +20,8 @@ type cacheEntry struct {
 // [4096]struct{entry; recentMiss} layout. This keeps the frequently scanned
 // entries denser in cache lines while misses use a separate counter array.
 type stringCache struct {
-	entries      [4096]atomic.Pointer[cacheEntry]
-	recentMisses [4096]atomic.Uint64
+	entries      [stringCacheSlots]atomic.Pointer[cacheEntry]
+	recentMisses [stringCacheSlots]atomic.Uint64
 }
 
 func newStringCache() *stringCache {
@@ -40,10 +42,15 @@ func (sc *stringCache) internAt(offset, size uint, data []byte) string {
 		return string(data[offset : offset+size])
 	}
 
-	i := offset % uint(len(sc.entries))
-	entry := &sc.entries[i]
+	const mask = stringCacheSlots - 1
+	primary := offset & mask
+	entry := &sc.entries[primary]
 
 	if cached := entry.Load(); cached != nil && cached.offset == offset {
+		return cached.str
+	}
+	alternate := stringCacheAlternateIndex(offset, primary)
+	if cached := sc.entries[alternate].Load(); cached != nil && cached.offset == offset {
 		return cached.str
 	}
 
@@ -54,14 +61,22 @@ func (sc *stringCache) internAt(offset, size uint, data []byte) string {
 	// The +1 bias reserves 0 as the "no prior miss" sentinel so the initial
 	// zero state of recentMisses[i] never spuriously matches a real offset of 0.
 	admissionValue := uint64(offset) + 1
-	if sc.recentMisses[i].Load() == admissionValue {
+	if sc.recentMisses[alternate].Load() == admissionValue {
+		if entry.Load() != nil {
+			entry = &sc.entries[alternate]
+		}
 		entry.Store(&cacheEntry{
 			str:    str,
 			offset: offset,
 		})
 	} else {
-		sc.recentMisses[i].Store(admissionValue)
+		sc.recentMisses[alternate].Store(admissionValue)
 	}
 
 	return str
+}
+
+func stringCacheAlternateIndex(offset, primary uint) uint {
+	const mask = stringCacheSlots - 1
+	return (primary + ((offset>>12)*0x9e37 | 1)) & mask
 }

--- a/internal/decoder/string_cache.go
+++ b/internal/decoder/string_cache.go
@@ -15,11 +15,8 @@ type cacheEntry struct {
 // miss for the same offset (see internAt).
 //
 // The arrays are intentionally separate rather than packed into a single
-// [4096]struct{entry; recentMiss} layout. Packing halves slot density
-// per cache line (4 vs 8) and measurably regresses BenchmarkStringCacheCold
-// by ~8%: cold-sweep workloads benefit more from dense linear scanning of
-// entries than from co-locating each entry with its rarely-touched miss
-// counter.
+// [4096]struct{entry; recentMiss} layout. This keeps the frequently scanned
+// entries denser in cache lines while misses use a separate counter array.
 type stringCache struct {
 	entries      [4096]atomic.Pointer[cacheEntry]
 	recentMisses [4096]atomic.Uint64

--- a/internal/decoder/string_cache_test.go
+++ b/internal/decoder/string_cache_test.go
@@ -62,30 +62,27 @@ func TestStringCacheTwoMissAdmission(t *testing.T) {
 		"cache hit must return the admitted string's backing data, not a fresh allocation")
 }
 
-// TestStringCacheNoAdmissionOnSlotCollision verifies that two offsets mapping
-// to the same slot alternately miss without admitting. The Swap rule encodes
-// "saw the same offset twice in a row" — alternation never matches, so the
-// slot stays empty and we avoid thrashing the cache with one-off collisions.
-func TestStringCacheNoAdmissionOnSlotCollision(t *testing.T) {
+func TestStringCacheUsesAlternateSlotOnCollision(t *testing.T) {
 	cache := newStringCache()
-	const slotCount = uint(4096)
-	data := make([]byte, slotCount+5)
+	const offsetA, offsetB uint = 0, stringCacheSlots
+	data := make([]byte, offsetB+5)
 	for i := range data {
 		data[i] = 'a' + byte(i%26)
 	}
 
-	const offsetA, offsetB uint = 0, slotCount
-	require.Equal(t, offsetA%slotCount, offsetB%slotCount,
-		"test setup requires colliding slots")
+	primaryA := offsetA & (stringCacheSlots - 1)
+	primaryB := offsetB & (stringCacheSlots - 1)
+	alternateA := stringCacheAlternateIndex(offsetA, primaryA)
+	alternateB := stringCacheAlternateIndex(offsetB, primaryB)
+	require.Equal(t, primaryA, primaryB, "test setup requires colliding primary slots")
+	require.NotEqual(t, alternateA, alternateB, "alternate slots must differ")
 
-	for range 4 {
+	for range 3 {
 		_ = cache.internAt(offsetA, 5, data)
-		require.Nil(t, cache.entries[offsetA%slotCount].Load(),
-			"alternating offsets must not admit at offsetA miss")
 		_ = cache.internAt(offsetB, 5, data)
-		require.Nil(t, cache.entries[offsetB%slotCount].Load(),
-			"alternating offsets must not admit at offsetB miss")
 	}
+	require.Equal(t, offsetA, cache.entries[primaryA].Load().offset)
+	require.Equal(t, offsetB, cache.entries[alternateB].Load().offset)
 }
 
 // TestStringCacheConcurrent stresses the lock-free cache with multiple
@@ -125,10 +122,14 @@ func TestStringCacheConcurrent(t *testing.T) {
 	wg.Wait()
 
 	for i, off := range offsets {
-		entry := cache.entries[off%uint(len(cache.entries))].Load()
+		primary := off & (stringCacheSlots - 1)
+		alternate := stringCacheAlternateIndex(off, primary)
+		entry := cache.entries[primary].Load()
+		if entry == nil || entry.offset != off {
+			entry = cache.entries[alternate].Load()
+		}
 		require.NotNil(t, entry,
-			"hot offset %d (slot %d) should be admitted after concurrent stress",
-			off, off%uint(len(cache.entries)))
+			"hot offset %d should be admitted after concurrent stress", off)
 		require.Equal(t, off, entry.offset)
 		require.Equal(t, expected[i], entry.str)
 	}
@@ -145,14 +146,15 @@ func BenchmarkStringCacheHot(b *testing.B) {
 
 func BenchmarkStringCacheCold(b *testing.B) {
 	cache := newStringCache()
-	data := make([]byte, 4096+5)
+	const collidingOffset = 1 << 24
+	data := make([]byte, collidingOffset+5)
 	for i := range data {
 		data[i] = 'a' + byte(i%26)
 	}
 
 	// These offsets collide in the same slot and alternate, so neither reaches
 	// the cache's two-consecutive-miss admission threshold.
-	offsets := [...]uint{0, 4096}
+	offsets := [...]uint{0, collidingOffset}
 	var i uint
 	b.ReportAllocs()
 	for b.Loop() {

--- a/internal/decoder/string_cache_test.go
+++ b/internal/decoder/string_cache_test.go
@@ -145,17 +145,18 @@ func BenchmarkStringCacheHot(b *testing.B) {
 
 func BenchmarkStringCacheCold(b *testing.B) {
 	cache := newStringCache()
-	data := make([]byte, 8192)
+	data := make([]byte, 4096+5)
 	for i := range data {
 		data[i] = 'a' + byte(i%26)
 	}
 
-	var offset uint
+	// These offsets collide in the same slot and alternate, so neither reaches
+	// the cache's two-consecutive-miss admission threshold.
+	offsets := [...]uint{0, 4096}
+	var i uint
+	b.ReportAllocs()
 	for b.Loop() {
-		benchmarkStringCacheSink = cache.internAt(offset, 5, data)
-		offset += 7
-		if offset+5 >= uint(len(data)) {
-			offset = 0
-		}
+		benchmarkStringCacheSink = cache.internAt(offsets[i%uint(len(offsets))], 5, data)
+		i++
 	}
 }

--- a/internal/decoder/verifier.go
+++ b/internal/decoder/verifier.go
@@ -2,6 +2,7 @@ package decoder
 
 import (
 	"reflect"
+	"unicode/utf8"
 
 	"github.com/oschwald/maxminddb-golang/v2/internal/mmdberrors"
 )
@@ -20,6 +21,13 @@ func (d *ReflectionDecoder) VerifyDataSection(offsets map[uint]bool) error {
 		if err != nil {
 			return mmdberrors.NewInvalidDatabaseError(
 				"received decoding error (%v) at offset of %v",
+				err,
+				offset,
+			)
+		}
+		if err := validateUTF8(data); err != nil {
+			return mmdberrors.NewInvalidDatabaseError(
+				"received validation error (%v) at offset of %v",
 				err,
 				offset,
 			)
@@ -60,6 +68,33 @@ func (d *ReflectionDecoder) VerifyDataSection(offsets map[uint]bool) error {
 			len(offsets),
 			pointerCount,
 		)
+	}
+	return nil
+}
+
+func validateUTF8(data any) error {
+	switch value := data.(type) {
+	case string:
+		if !utf8.ValidString(value) {
+			return mmdberrors.NewInvalidDatabaseError("invalid UTF-8 string")
+		}
+	case map[string]any:
+		for key, item := range value {
+			if !utf8.ValidString(key) {
+				return mmdberrors.NewInvalidDatabaseError("invalid UTF-8 map key")
+			}
+			if err := validateUTF8(item); err != nil {
+				return err
+			}
+		}
+	case []any:
+		for _, item := range value {
+			if err := validateUTF8(item); err != nil {
+				return err
+			}
+		}
+	default:
+		// Non-string scalar values require no UTF-8 validation.
 	}
 	return nil
 }

--- a/internal/decoder/verifier_test.go
+++ b/internal/decoder/verifier_test.go
@@ -1,0 +1,26 @@
+package decoder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyDataSectionRejectsInvalidUTF8(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "string", data: []byte{0x42, 0xff, 0xff}},
+		{name: "map key", data: []byte{0xe1, 0x41, 0xff, 0xe0}},
+		{name: "array element", data: []byte{0x01, 0x04, 0x42, 0xff, 0xff}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := New(tt.data)
+			err := d.VerifyDataSection(map[uint]bool{0: true})
+			require.ErrorContains(t, err, "invalid UTF-8")
+		})
+	}
+}

--- a/reader.go
+++ b/reader.go
@@ -124,6 +124,8 @@ const dataSectionSeparatorSize = 16
 
 var metadataStartMarker = []byte("\xAB\xCD\xEFMaxMind.com")
 
+var errInvalidIPAddress = errors.New("invalid IP address")
+
 // mmapCleanup holds the data needed to safely cleanup memory-mapped files.
 type mmapCleanup struct {
 	hasMapped *atomic.Bool
@@ -458,6 +460,9 @@ func (r *Reader) hasIPv4Subtree() bool {
 var zeroIP = netip.MustParseAddr("::")
 
 func (r *Reader) lookupPointer(ip netip.Addr) (uint, int, error) {
+	if !ip.IsValid() {
+		return 0, 0, errInvalidIPAddress
+	}
 	if r.Metadata.IPVersion == 4 && ip.Is6() {
 		return 0, 0, fmt.Errorf(
 			"error looking up '%s': you attempted to look up an IPv6 address in an IPv4-only database",

--- a/reader.go
+++ b/reader.go
@@ -683,9 +683,8 @@ func (r *Reader) traverseTree28(ip netip.Addr, node uint, stopBit int) (uint, in
 			// shift = 20 (bit=0) or 24 (bit=1): position the shared nibble's
 			// high or low 4 bits into the top of the assembled 28-bit node.
 			sharedByte := uint(buffer[baseOffset+3])
-			mask := uint(0xF0 >> (bit * 4))
 			shift := 20 + bit*4
-			nibble := ((sharedByte & mask) << shift)
+			nibble := (sharedByte << shift) & 0x0F000000
 
 			node = nibble |
 				(uint(buffer[offset]) << 16) |
@@ -717,9 +716,8 @@ func (r *Reader) traverseTree28(ip netip.Addr, node uint, stopBit int) (uint, in
 			offset := baseOffset + bit*4
 
 			sharedByte := uint(buffer[baseOffset+3])
-			mask := uint(0xF0 >> (bit * 4))
 			shift := 20 + bit*4
-			nibble := ((sharedByte & mask) << shift)
+			nibble := (sharedByte << shift) & 0x0F000000
 
 			node = nibble |
 				(uint(buffer[offset]) << 16) |

--- a/reader.go
+++ b/reader.go
@@ -313,6 +313,8 @@ func (r *Reader) Close() error {
 		err = munmap(r.buffer)
 	}
 	r.buffer = nil
+	r.decoder = decoder.ReflectionDecoder{}
+	r.dataSectionSize = 0
 	return err
 }
 

--- a/reader.go
+++ b/reader.go
@@ -205,8 +205,7 @@ func (m Metadata) BuildTime() time.Time {
 }
 
 type readerOptions struct {
-	// Intentionally empty for now. ReaderOption callbacks are still invoked so
-	// adding options in a future release is non-breaking.
+	disableStringCache bool
 }
 
 // ReaderOption are options for [Open] and [OpenBytes].
@@ -214,6 +213,15 @@ type readerOptions struct {
 // This was added to allow for future options, e.g., for caching, without
 // causing a breaking API change.
 type ReaderOption func(*readerOptions)
+
+// DisableStringCache disables caching of repeatedly decoded strings. This
+// reduces each Reader's fixed memory usage by approximately 64 KiB, but may
+// increase allocations when the same records are decoded repeatedly.
+func DisableStringCache() ReaderOption {
+	return func(options *readerOptions) {
+		options.disableStringCache = true
+	}
+}
 
 // Open takes a string path to a MaxMind DB file and any options. It returns a
 // Reader structure or an error. The database file is opened using a memory
@@ -325,7 +333,7 @@ func OpenBytes(buffer []byte, options ...ReaderOption) (*Reader, error) {
 	}
 
 	metadataStart += len(metadataStartMarker)
-	metadataDecoder := decoder.New(buffer[metadataStart:])
+	metadataDecoder := decoder.NewWithoutStringCache(buffer[metadataStart:])
 
 	var metadata Metadata
 
@@ -352,7 +360,12 @@ func OpenBytes(buffer []byte, options ...ReaderOption) (*Reader, error) {
 		return nil, mmdberrors.NewInvalidDatabaseError("the MaxMind DB contains invalid metadata")
 	}
 	dataSection := buffer[dataSectionStart:dataSectionEnd]
-	d := decoder.New(dataSection)
+	var d decoder.ReflectionDecoder
+	if opts.disableStringCache {
+		d = decoder.NewWithoutStringCache(dataSection)
+	} else {
+		d = decoder.New(dataSection)
+	}
 
 	reader := &Reader{
 		buffer:          buffer,

--- a/reader.go
+++ b/reader.go
@@ -384,6 +384,7 @@ func (r *Reader) Lookup(ip netip.Addr) Result {
 	}
 	pointer, prefixLen, err := r.lookupPointer(ip)
 	if err != nil {
+		runtime.KeepAlive(r)
 		return Result{
 			ip:        ip,
 			prefixLen: uint8(prefixLen),
@@ -391,6 +392,7 @@ func (r *Reader) Lookup(ip netip.Addr) Result {
 		}
 	}
 	if pointer == 0 {
+		runtime.KeepAlive(r)
 		return Result{
 			ip:        ip,
 			prefixLen: uint8(prefixLen),
@@ -398,6 +400,7 @@ func (r *Reader) Lookup(ip netip.Addr) Result {
 		}
 	}
 	offset, err := r.resolveDataPointer(pointer)
+	runtime.KeepAlive(r)
 	return Result{
 		reader:    r,
 		ip:        ip,

--- a/reader_test.go
+++ b/reader_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sync"
 	"testing"
 	"time"
 
@@ -1458,60 +1457,43 @@ func BenchmarkDecodePathCountryCode(b *testing.B) {
 	require.NoError(b, db.Close(), "error on close")
 }
 
-// BenchmarkCityLookupConcurrent tests concurrent city lookups to demonstrate
-// string cache performance under concurrent load.
+// BenchmarkCityLookupConcurrent measures lookup and decode scaling under
+// concurrent access to the shared string cache.
 func BenchmarkCityLookupConcurrent(b *testing.B) {
-	db, err := Open("GeoLite2-City.mmdb")
+	db, err := Open(testFile("GeoIP2-City-Test.mmdb"))
 	require.NoError(b, err)
-	defer func() {
-		require.NoError(b, db.Close(), "error on close")
-	}()
+	b.Cleanup(func() { require.NoError(b, db.Close(), "error on close") })
 
-	// Test with different numbers of concurrent goroutines
+	var addresses []netip.Addr
+	for result := range db.Networks() {
+		require.NoError(b, result.Err())
+		addresses = append(addresses, result.Prefix().Addr())
+	}
+	require.NotEmpty(b, addresses)
+
 	goroutineCounts := []int{1, 4, 16, 64}
-
 	for _, numGoroutines := range goroutineCounts {
 		b.Run(fmt.Sprintf("goroutines_%d", numGoroutines), func(b *testing.B) {
-			// Each goroutine performs 100 lookups
-			const lookupsPerGoroutine = 100
+			previousProcs := runtime.GOMAXPROCS(numGoroutines)
+			b.Cleanup(func() { runtime.GOMAXPROCS(previousProcs) })
+			b.ReportAllocs()
 			b.ResetTimer()
 
-			for range b.N {
-				var wg sync.WaitGroup
-				wg.Add(numGoroutines)
-
-				for range numGoroutines {
-					go func() {
-						defer wg.Done()
-
-						//nolint:gosec // this is a test
-						r := rand.New(rand.NewSource(time.Now().UnixNano()))
-						s := make(net.IP, 4)
-						var result benchmarkCity
-
-						for range lookupsPerGoroutine {
-							ip := randomIPv4Address(r, s)
-							lookupResult := db.Lookup(ip)
-							err := lookupResult.Decode(&result)
-							if err != nil {
-								b.Error(err)
-								return
-							}
-							result.Traits.IPAddress = ip
-							result.Traits.Network = lookupResult.Prefix()
-							// Access string fields to exercise the cache
-							_ = result.City.Names
-							_ = result.Country.Names
-						}
-					}()
+			b.RunParallel(func(pb *testing.PB) {
+				var result benchmarkCity
+				var i uint
+				for pb.Next() {
+					ip := addresses[i%uint(len(addresses))]
+					lookupResult := db.Lookup(ip)
+					if err := lookupResult.Decode(&result); err != nil {
+						b.Error(err)
+						return
+					}
+					result.Traits.IPAddress = ip
+					result.Traits.Network = lookupResult.Prefix()
+					i++
 				}
-
-				wg.Wait()
-			}
-
-			// Report operations per second
-			totalOps := int64(b.N) * int64(numGoroutines) * int64(lookupsPerGoroutine)
-			b.ReportMetric(float64(totalOps)/b.Elapsed().Seconds(), "lookups/sec")
+			})
 		})
 	}
 }

--- a/reader_test.go
+++ b/reader_test.go
@@ -1002,6 +1002,20 @@ func TestUsingClosedDatabase(t *testing.T) {
 	assert.Zero(t, reader.dataSectionSize)
 }
 
+func TestLookupRejectsInvalidAddress(t *testing.T) {
+	for _, recordSize := range []uint{24, 28, 32} {
+		t.Run(fmt.Sprintf("%d-bit", recordSize), func(t *testing.T) {
+			reader, err := Open(testFile(fmt.Sprintf("MaxMind-DB-test-ipv4-%d.mmdb", recordSize)))
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, reader.Close()) })
+
+			result := reader.Lookup(netip.Addr{})
+			require.EqualError(t, result.Err(), "invalid IP address")
+			require.False(t, result.Found())
+		})
+	}
+}
+
 func TestResultDecodeAfterReaderClose(t *testing.T) {
 	reader, err := Open(testFile("MaxMind-DB-test-decoder.mmdb"))
 	require.NoError(t, err)
@@ -1327,6 +1341,75 @@ func BenchmarkCityLookupOnly(b *testing.B) {
 		}
 	}
 	require.NoError(b, db.Close(), "error on close")
+}
+
+func BenchmarkTestDatabaseLookup(b *testing.B) {
+	db, err := Open(testFile("MaxMind-DB-test-ipv4-28.mmdb"))
+	require.NoError(b, err)
+	b.Cleanup(func() { require.NoError(b, db.Close()) })
+
+	addresses := [...]netip.Addr{
+		netip.MustParseAddr("1.1.1.1"),
+		netip.MustParseAddr("1.1.1.2"),
+		netip.MustParseAddr("2.2.2.2"),
+		netip.MustParseAddr("255.255.255.255"),
+	}
+
+	var i uint
+	for b.Loop() {
+		result := db.Lookup(addresses[i%uint(len(addresses))])
+		if err := result.Err(); err != nil {
+			b.Fatal(err)
+		}
+		i++
+	}
+}
+
+func BenchmarkTestDatabaseLookupIPv6(b *testing.B) {
+	db, err := Open(testFile("MaxMind-DB-test-ipv6-28.mmdb"))
+	require.NoError(b, err)
+	b.Cleanup(func() { require.NoError(b, db.Close()) })
+
+	addresses := [...]netip.Addr{
+		netip.MustParseAddr("2001::1"),
+		netip.MustParseAddr("2001:db8::1"),
+		netip.MustParseAddr("abcd::1"),
+		netip.MustParseAddr("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff"),
+	}
+
+	var i uint
+	for b.Loop() {
+		result := db.Lookup(addresses[i%uint(len(addresses))])
+		if err := result.Err(); err != nil {
+			b.Fatal(err)
+		}
+		i++
+	}
+}
+
+var benchmarkLookupPointerSink uint
+
+func BenchmarkTestDatabaseLookupPointer(b *testing.B) {
+	db, err := Open(testFile("MaxMind-DB-test-ipv4-28.mmdb"))
+	require.NoError(b, err)
+	b.Cleanup(func() { require.NoError(b, db.Close()) })
+
+	addresses := [...]netip.Addr{
+		netip.MustParseAddr("1.1.1.1"),
+		netip.MustParseAddr("1.1.1.2"),
+		netip.MustParseAddr("2.2.2.2"),
+		netip.MustParseAddr("255.255.255.255"),
+	}
+
+	var i uint
+	for b.Loop() {
+		pointer, _, err := db.lookupPointer(addresses[i%uint(len(addresses))])
+		if err != nil {
+			b.Fatal(err)
+		}
+		benchmarkLookupPointerSink = pointer
+		i++
+	}
 }
 
 func BenchmarkDecodeCountryCodeWithStruct(b *testing.B) {

--- a/reader_test.go
+++ b/reader_test.go
@@ -1411,6 +1411,30 @@ func BenchmarkTestDatabaseLookupPointer(b *testing.B) {
 	}
 }
 
+func BenchmarkTestDatabaseCityLookup(b *testing.B) {
+	db, err := Open(testFile("GeoIP2-City-Test.mmdb"))
+	require.NoError(b, err)
+	b.Cleanup(func() { require.NoError(b, db.Close()) })
+
+	var addresses []netip.Addr
+	for result := range db.Networks() {
+		require.NoError(b, result.Err())
+		addresses = append(addresses, result.Prefix().Addr())
+	}
+	require.NotEmpty(b, addresses)
+
+	var result benchmarkCity
+	var i uint
+	b.ResetTimer()
+	for b.Loop() {
+		lookupResult := db.Lookup(addresses[i%uint(len(addresses))])
+		if err := lookupResult.Decode(&result); err != nil {
+			b.Fatal(err)
+		}
+		i++
+	}
+}
+
 func BenchmarkDecodeCountryCodeWithStruct(b *testing.B) {
 	db, err := Open("GeoLite2-City.mmdb")
 	require.NoError(b, err)

--- a/reader_test.go
+++ b/reader_test.go
@@ -77,6 +77,17 @@ func TestOpenBytesAppliesReaderOptions(t *testing.T) {
 	require.True(t, optionCalled)
 }
 
+func TestDisableStringCache(t *testing.T) {
+	reader, err := Open(testFile("MaxMind-DB-test-decoder.mmdb"), DisableStringCache())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reader.Close()) })
+
+	var record map[string]any
+	err = reader.Lookup(netip.MustParseAddr("::1.1.1.0")).Decode(&record)
+	require.NoError(t, err)
+	require.NotEmpty(t, record)
+}
+
 func TestReaderLeaks(t *testing.T) {
 	collected := make(chan struct{})
 
@@ -1130,6 +1141,34 @@ func BenchmarkOpen(b *testing.B) {
 	}
 	assert.NotNil(b, db)
 	require.NoError(b, db.Close(), "error on close")
+}
+
+func BenchmarkOpenBytesOptions(b *testing.B) {
+	data, err := os.ReadFile(testFile("MaxMind-DB-test-decoder.mmdb"))
+	require.NoError(b, err)
+
+	tests := []struct {
+		name    string
+		options []ReaderOption
+	}{
+		{name: "default"},
+		{name: "disable_string_cache", options: []ReaderOption{DisableStringCache()}},
+	}
+
+	for _, test := range tests {
+		b.Run(test.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				reader, err := OpenBytes(data, test.options...)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if err := reader.Close(); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
 }
 
 func BenchmarkInterfaceLookup(b *testing.B) {

--- a/reader_test.go
+++ b/reader_test.go
@@ -998,6 +998,8 @@ func TestUsingClosedDatabase(t *testing.T) {
 
 	err = reader.LookupOffset(0).Decode(recordInterface)
 	assert.Equal(t, "cannot call LookupOffset on a closed database", err.Error())
+	assert.Zero(t, reader.decoder, "Close should release decoder-owned data")
+	assert.Zero(t, reader.dataSectionSize)
 }
 
 func TestResultDecodeAfterReaderClose(t *testing.T) {

--- a/result.go
+++ b/result.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"math"
 	"net/netip"
+	"runtime"
 )
 
 const notFound uint = math.MaxUint
@@ -39,7 +40,9 @@ func (r Result) Decode(v any) error {
 		return errors.New("cannot call Decode on a closed database")
 	}
 
-	return r.reader.decoder.Decode(r.offset, v)
+	err := r.reader.decoder.Decode(r.offset, v)
+	runtime.KeepAlive(r.reader)
+	return err
 }
 
 // DecodePath unmarshals a value from data section into v, following the
@@ -99,7 +102,9 @@ func (r Result) DecodePath(v any, path ...any) error {
 	if r.reader == nil || r.reader.buffer == nil {
 		return errors.New("cannot call DecodePath on a closed database")
 	}
-	return r.reader.decoder.DecodePath(r.offset, path, v)
+	err := r.reader.decoder.DecodePath(r.offset, path, v)
+	runtime.KeepAlive(r.reader)
+	return err
 }
 
 // Err provides a way to check whether there was an error during the lookup

--- a/result_test.go
+++ b/result_test.go
@@ -7,6 +7,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+var benchmarkFoundSink bool
+
+func BenchmarkResultFound(b *testing.B) {
+	result := Result{reader: &Reader{}, offset: 1}
+	for b.Loop() {
+		benchmarkFoundSink = result.Found()
+	}
+}
+
 func TestResultPrefixUsesIPv4StartBitDepth(t *testing.T) {
 	reader := &Reader{
 		Metadata:          Metadata{IPVersion: 6, NodeCount: 8},

--- a/traverse.go
+++ b/traverse.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"iter"
 	"net/netip"
+	"runtime"
 
 	"github.com/oschwald/maxminddb-golang/v2/internal/mmdberrors"
 )
@@ -134,7 +135,7 @@ func (r *Reader) NetworksWithin(prefix netip.Prefix, options ...NetworksOption) 
 			return
 		}
 
-		prefix, err := netIP.Prefix(bit)
+		networkPrefix, err := netIP.Prefix(bit)
 		if err != nil {
 			yield(Result{
 				ip:        ip,
@@ -147,7 +148,7 @@ func (r *Reader) NetworksWithin(prefix netip.Prefix, options ...NetworksOption) 
 		nodes := make([]netNode, 0, 64)
 		nodes = append(nodes,
 			netNode{
-				ip:      prefix.Addr(),
+				ip:      networkPrefix.Addr(),
 				bit:     uint(bit),
 				pointer: pointer,
 			},
@@ -248,6 +249,7 @@ func (r *Reader) NetworksWithin(prefix netip.Prefix, options ...NetworksOption) 
 				node.pointer = leftPointer
 			}
 		}
+		runtime.KeepAlive(r)
 	}
 }
 

--- a/verifier.go
+++ b/verifier.go
@@ -2,6 +2,7 @@ package maxminddb
 
 import (
 	"runtime"
+	"unicode/utf8"
 
 	"github.com/oschwald/maxminddb-golang/v2/internal/mmdberrors"
 )
@@ -63,6 +64,19 @@ func (v *verifier) verifyMetadata() error {
 			"non-empty string",
 			metadata.DatabaseType,
 		)
+	}
+	if !utf8.ValidString(metadata.DatabaseType) {
+		return mmdberrors.NewInvalidDatabaseError("database_type contains invalid UTF-8")
+	}
+	for language, description := range metadata.Description {
+		if !utf8.ValidString(language) || !utf8.ValidString(description) {
+			return mmdberrors.NewInvalidDatabaseError("description contains invalid UTF-8")
+		}
+	}
+	for _, language := range metadata.Languages {
+		if !utf8.ValidString(language) {
+			return mmdberrors.NewInvalidDatabaseError("languages contains invalid UTF-8")
+		}
 	}
 
 	if len(metadata.Description) == 0 {

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -63,6 +63,61 @@ func TestVerifyOnBrokenDatabases(t *testing.T) {
 	}
 }
 
+func TestVerifyMetadataRejectsInvalidUTF8(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Metadata)
+		errMsg string
+	}{
+		{
+			name: "database type",
+			mutate: func(metadata *Metadata) {
+				metadata.DatabaseType = "Test\xff"
+			},
+			errMsg: "database_type contains invalid UTF-8",
+		},
+		{
+			name: "description key",
+			mutate: func(metadata *Metadata) {
+				metadata.Description = map[string]string{"\xff": "test"}
+			},
+			errMsg: "description contains invalid UTF-8",
+		},
+		{
+			name: "description value",
+			mutate: func(metadata *Metadata) {
+				metadata.Description = map[string]string{"en": "test\xff"}
+			},
+			errMsg: "description contains invalid UTF-8",
+		},
+		{
+			name: "languages",
+			mutate: func(metadata *Metadata) {
+				metadata.Languages = []string{"en\xff"}
+			},
+			errMsg: "languages contains invalid UTF-8",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metadata := Metadata{
+				Description:              map[string]string{"en": "test"},
+				DatabaseType:             "Test",
+				BinaryFormatMajorVersion: 2,
+				BinaryFormatMinorVersion: 0,
+				IPVersion:                4,
+				NodeCount:                1,
+				RecordSize:               24,
+			}
+			tt.mutate(&metadata)
+
+			v := verifier{reader: &Reader{Metadata: metadata}}
+			require.ErrorContains(t, v.verifyMetadata(), tt.errMsg)
+		})
+	}
+}
+
 func TestVerifyDataSectionSeparatorOutOfBounds(t *testing.T) {
 	v := verifier{reader: &Reader{
 		buffer: []byte{0x00},


### PR DESCRIPTION
## Summary

- reject impossible or malformed large containers before destination allocation
- keep memory-mapped readers alive during lookup, decode, and iteration, and release decoder references on close
- reject invalid addresses, invalid UTF-8 during verification, and invalid pointer chains consistently
- reduce reader opening memory and add `DisableStringCache`
- optimize 28-bit tree traversal, recurring string-cache collisions, and reflected struct field lookup
- correct cold-cache and concurrent lookup benchmarks

## Performance

Benchmarks used Go 1.26.4 on Linux/amd64 with `GOMAXPROCS=1` and alternating before/after samples.

- `OpenBytes`: approximately 42% faster and 49.7% fewer allocated bytes
- IPv4 lookup for 28-bit trees: approximately 4% faster
- IPv6 lookup for 28-bit trees: approximately 6% faster
- checked city lookup plus decode: approximately 13% faster
- checked city allocation: 16 B/op and 1 allocation to 0 B/op and 0 allocations
- reused 1,024-entry slice decoding: approximately 16% faster and allocation-free

No allocation regressions were found. Tests against real 24-bit and 32-bit databases in `/var/lib/GeoIP` did not identify a justified traversal rewrite for those formats.

## Validation

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- repository commit hooks and linters
- `FuzzDecode` short fuzz run
- focused alternating lookup, decode, container, cache, and concurrency benchmarks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `DisableStringCache()` reader option for lower-memory decoding.
* **Performance**
  * Faster IPv4/IPv6 lookups and decoding with fewer allocations and improved container/struct handling.
  * Benchmark methodology updated for more consistent cold-cache/concurrent measurements.
* **Bug Fixes**
  * Stricter rejection of malformed containers/pointers (including “pointer to pointer”), invalid IP addresses, and invalid UTF-8 in both metadata and decoded data.
  * Improved iterator/decoder lifetime safety and corrected network prefix handling.
* **Tests**
  * Added/updated unit tests and new benchmarks for cache-disabled decoding and validation failures.
* **Documentation**
  * Updated the changelog under “Unreleased.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->