### PR TITLE
Expose resolved cursor offsets

### DIFF
--- a/internal/decoder/cursor.go
+++ b/internal/decoder/cursor.go
@@ -81,6 +81,16 @@ func (d *Decoder) Advance(next Cursor) error {
 	return nil
 }
 
+// Offset returns the current value's control-byte offset. It resolves one
+// pointer so that cursors pointing to the same value return the same offset.
+// It returns the cursor's original offset if the pointer cannot be resolved.
+func (c Cursor) Offset() uint {
+	if c.decoder == nil {
+		return c.offset
+	}
+	return c.decoder.resolvedValueOffset(c.offset)
+}
+
 // Kind returns the resolved kind at the cursor without consuming it.
 func (c Cursor) Kind() (Kind, error) {
 	if err := c.validate(); err != nil {

--- a/internal/decoder/decoder.go
+++ b/internal/decoder/decoder.go
@@ -346,23 +346,27 @@ func (d *Decoder) PeekKind() (Kind, error) {
 // that multiple pointers to the same data return the same offset, which
 // is important for caching purposes.
 func (d *Decoder) Offset() uint {
+	return d.d.resolvedValueOffset(d.offset)
+}
+
+func (d *DataDecoder) resolvedValueOffset(offset uint) uint {
 	// This intentionally does not use resolveCtrlData: Offset must return the
 	// resolved value's control-byte offset, not the post-control-byte payload
 	// offset used by read methods.
-	kindNum, size, ctrlEndOffset, err := d.d.decodeCtrlData(d.offset)
+	kindNum, size, ctrlEndOffset, err := d.decodeCtrlData(offset)
 	if err != nil || kindNum != KindPointer {
-		return d.offset
+		return offset
 	}
 
-	pointer, _, err := d.d.decodePointer(size, ctrlEndOffset)
+	pointer, _, err := d.decodePointer(size, ctrlEndOffset)
 	if err != nil {
 		// Return original offset to avoid breaking the public API.
 		// The caller will encounter the same error when they try to read.
-		return d.offset
+		return offset
 	}
-	kindNum, _, _, err = d.d.decodeCtrlData(pointer)
+	kindNum, _, _, err = d.decodeCtrlData(pointer)
 	if err != nil || kindNum == KindPointer {
-		return d.offset
+		return offset
 	}
 	return pointer
 }

--- a/internal/decoder/decoder_test.go
+++ b/internal/decoder/decoder_test.go
@@ -649,19 +649,26 @@ func TestOffsetReturnsValueStart(t *testing.T) {
 			offset:         0,
 			expectedOffset: 0,
 		},
+		"truncated pointer": {
+			buffer:         []byte{0x20},
+			offset:         0,
+			expectedOffset: 0,
+		},
 	}
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			dd := NewDataDecoder(tt.buffer)
-			offset := NewDecoder(dd, tt.offset).Offset()
+			decoder := NewDecoder(dd, tt.offset)
+			offset := decoder.Offset()
 
 			require.Equal(t, tt.expectedOffset, offset)
+			require.Equal(t, tt.expectedOffset, decoder.Cursor().Offset())
 			if tt.expectedValue == "" {
 				return
 			}
 
-			decoder := NewDecoder(dd, offset)
+			decoder = NewDecoder(dd, offset)
 			value, err := decoder.ReadString()
 			require.NoError(t, err)
 			require.Equal(t, tt.expectedValue, value)

--- a/mmdbdata/cursor_test.go
+++ b/mmdbdata/cursor_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestZeroContainerCursorsAreRejected(t *testing.T) {
+	require.Zero(t, Cursor{}.Offset())
+
 	t.Run("map", func(t *testing.T) {
 		var entries MapCursor
 		require.Zero(t, entries.Size())

--- a/mmdbdata/type.go
+++ b/mmdbdata/type.go
@@ -56,6 +56,7 @@ type Decoder = decoder.Decoder
 //
 // Cursor provides these operations:
 //
+//	func (Cursor) Offset() uint
 //	func (Cursor) Kind() (Kind, error)
 //	func (Cursor) Skip() (Cursor, error)
 //	func (Cursor) ReadBool() (bool, Cursor, error)
@@ -75,6 +76,8 @@ type Decoder = decoder.Decoder
 //	func (Cursor) Unmarshal(Unmarshaler) (Cursor, error)
 //	func (Cursor) UnmarshalCursor(CursorUnmarshaler) (Cursor, error)
 //
+// Offset returns the resolved value's control-byte offset. It follows one
+// pointer so callers can use the result to cache values within one database.
 // Kind resolves a valid pointer and reports its target kind without consuming
 // the cursor.
 //


### PR DESCRIPTION
## Summary

- Add `Cursor.Offset()` for retrieving a value's resolved control-byte offset.
- Share pointer-offset resolution between `Cursor` and the legacy `Decoder` API.
- Document the API and cover direct values, pointers, malformed pointers, and zero cursors.

## Motivation

Cursor-based decoders may cache containers by source offset so repeated pointers can reuse decoded values. The legacy `Decoder` exposes its resolved offset, but `Cursor` does not. This addition allows such decoders to move to the cursor API without discarding their caches.

## Testing

- `go test ./...`
- `go test -race ./...`
- `GOARCH=386 go test ./...`
- `go vet ./...`
- `golangci-lint run`
