### PR TITLE
Expose checked cursor offsets and fix metadata and generator edge cases

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "test-data"]
-	path = test-data
+	path = testdata
 	url = https://github.com/maxmind/MaxMind-DB.git

--- a/.precious.toml
+++ b/.precious.toml
@@ -1,5 +1,5 @@
 exclude = [
-  "test-data/**/*",
+  "testdata/**/*",
   "vendor/**/*",
 ]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   bytes in reflection and generated decoders, plus bounded cursor reads.
   Field names containing commas must now be single-quoted.
 - Made generated decoders reject duplicate recognized map keys.
+- Added `mmdbdata.Cursor.Offset()` to retrieve a value's resolved control-byte
+  offset for caching within a database. It returns an error when resolution
+  fails; the legacy `Decoder.Offset()` retains its original-offset fallback.
 - Improved performance:
   - Reduced 28-bit search-tree lookup overhead with single-word node reads.
   - Extended bounded cursor string fast paths to wider data pointers.

--- a/example_test.go
+++ b/example_test.go
@@ -11,7 +11,7 @@ import (
 
 // This example shows how to decode to a struct.
 func ExampleReader_Lookup_struct() {
-	db, err := maxminddb.Open("test-data/test-data/GeoIP2-City-Test.mmdb")
+	db, err := maxminddb.Open("testdata/test-data/GeoIP2-City-Test.mmdb")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -36,7 +36,7 @@ func ExampleReader_Lookup_struct() {
 
 // This example demonstrates how to decode to an any.
 func ExampleReader_Lookup_interface() {
-	db, err := maxminddb.Open("test-data/test-data/GeoIP2-City-Test.mmdb")
+	db, err := maxminddb.Open("testdata/test-data/GeoIP2-City-Test.mmdb")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -57,7 +57,7 @@ func ExampleReader_Lookup_interface() {
 // This example demonstrates how to iterate over all networks in the
 // database.
 func ExampleReader_Networks() {
-	db, err := maxminddb.Open("test-data/test-data/GeoIP2-Connection-Type-Test.mmdb")
+	db, err := maxminddb.Open("testdata/test-data/GeoIP2-Connection-Type-Test.mmdb")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -104,7 +104,7 @@ func ExampleReader_Networks() {
 
 // This example demonstrates how to validate a MaxMind DB file and access metadata.
 func ExampleReader_Verify() {
-	db, err := maxminddb.Open("test-data/test-data/GeoIP2-City-Test.mmdb")
+	db, err := maxminddb.Open("testdata/test-data/GeoIP2-City-Test.mmdb")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -138,7 +138,7 @@ func ExampleReader_Verify() {
 // This example demonstrates how to iterate over all networks in the
 // database which are contained within an arbitrary network.
 func ExampleReader_NetworksWithin() {
-	db, err := maxminddb.Open("test-data/test-data/GeoIP2-Connection-Type-Test.mmdb")
+	db, err := maxminddb.Open("testdata/test-data/GeoIP2-Connection-Type-Test.mmdb")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -175,7 +175,7 @@ func ExampleReader_NetworksWithin() {
 // This example demonstrates how to use SkipEmptyValues to iterate only over
 // networks that have actual data, skipping those with empty maps or arrays.
 func ExampleSkipEmptyValues() {
-	db, err := maxminddb.Open("test-data/test-data/GeoIP2-Anonymous-IP-Test.mmdb")
+	db, err := maxminddb.Open("testdata/test-data/GeoIP2-Anonymous-IP-Test.mmdb")
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -356,7 +356,7 @@ func (c *CustomCity) unmarshalNames(cursor mmdbdata.Cursor) (mmdbdata.Cursor, er
 // Types implementing CursorUnmarshaler automatically use custom decoding logic
 // instead of reflection, similar to how json.Unmarshaler works with encoding/json.
 func Example_cursorUnmarshaler() {
-	db, err := maxminddb.Open("test-data/test-data/GeoIP2-City-Test.mmdb")
+	db, err := maxminddb.Open("testdata/test-data/GeoIP2-City-Test.mmdb")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -360,10 +360,10 @@ func parseSimpleInt(s string) (int, bool) {
 	return num, true
 }
 
-// getAllTestMMDBFiles returns smaller MMDB files from the test-data directory.
+// getAllTestMMDBFiles returns smaller MMDB files from the testdata directory.
 // Large files are excluded to keep fuzzing fast and prevent timeouts.
 func getAllTestMMDBFiles() []string {
-	testDataDir := filepath.Join("test-data", "test-data")
+	testDataDir := filepath.Join("testdata", "test-data")
 	entries, err := os.ReadDir(testDataDir)
 	if err != nil {
 		return nil

--- a/internal/decoder/budget_test.go
+++ b/internal/decoder/budget_test.go
@@ -1009,6 +1009,34 @@ func TestTypedStructDoesNotChargeIgnoredPayload(t *testing.T) {
 	require.NoError(t, decodeAt(buf, 0, &out))
 }
 
+func TestVerifyMetadataBudgetsUnknownFields(t *testing.T) {
+	t.Run("container expansion", func(t *testing.T) {
+		buf := append(mapHeader(1), encodedString("unknown")...)
+		for range 20 {
+			target := len(buf) + 6
+			buf = append(buf, sliceHeader(2)...)
+			buf = append(buf, ptr(target)...)
+			buf = append(buf, ptr(target)...)
+		}
+		buf = append(buf, 0xa0)
+
+		requireExpansionLimit(t, VerifyMetadata(buf))
+	})
+
+	t.Run("payload expansion", func(t *testing.T) {
+		buf := append(mapHeader(1), encodedString("unknown")...)
+		buf = append(buf, sliceHeader(payloadFanOut)...)
+		target := len(buf) + payloadFanOut*2
+		require.Less(t, target, 2048)
+		for range payloadFanOut {
+			buf = append(buf, ptr(target)...)
+		}
+		buf = append(buf, stringLeaf(100<<10)...)
+
+		requireExpansionLimit(t, VerifyMetadata(buf))
+	})
+}
+
 func TestVerifyDataSectionBudgetsEachRecord(t *testing.T) {
 	d := New(binaryFanOut())
 	err := d.VerifyDataSection(map[uint]bool{0: true})

--- a/internal/decoder/cursor.go
+++ b/internal/decoder/cursor.go
@@ -86,6 +86,41 @@ func (d *Decoder) Advance(next Cursor) error {
 	return nil
 }
 
+// Offset returns the current value's control-byte offset without consuming it.
+// It resolves one pointer so values in the same database can be cached by their
+// shared offset. It returns an error for a zero cursor, malformed control data,
+// or a pointer that cannot be resolved, including a pointer-to-pointer chain.
+// A successful call does not validate the value's payload.
+func (c Cursor) Offset() (uint, error) {
+	if err := c.validate(); err != nil {
+		return 0, err
+	}
+	// resolveCtrlData returns the payload offset, but cache keys need the
+	// control-byte offset, including for values with extended headers.
+	kind, size, ctrlEnd, err := c.decoder.decodeCtrlData(c.offset)
+	if err != nil {
+		return 0, c.wrapError(err)
+	}
+	if kind != KindPointer {
+		return c.offset, nil
+	}
+
+	pointer, _, err := c.decoder.decodePointer(size, ctrlEnd)
+	if err != nil {
+		return 0, c.wrapError(err)
+	}
+	kind, _, _, err = c.decoder.decodeCtrlData(pointer)
+	if err != nil {
+		return 0, c.wrapError(err)
+	}
+	if kind == KindPointer {
+		return 0, c.wrapError(
+			mmdberrors.NewInvalidDatabaseError("pointer-to-pointer chain detected"),
+		)
+	}
+	return pointer, nil
+}
+
 // Kind returns the resolved kind at the cursor without consuming it.
 func (c Cursor) Kind() (Kind, error) {
 	if err := c.validate(); err != nil {

--- a/internal/decoder/decoder.go
+++ b/internal/decoder/decoder.go
@@ -342,6 +342,8 @@ func (d *Decoder) PeekKind() (Kind, error) {
 // pointer and returns the offset of the actual data. This ensures
 // that multiple pointers to the same data return the same offset, which
 // is important for caching purposes.
+// If resolution fails, it returns the original offset. Use Cursor.Offset to
+// retrieve resolution errors.
 func (d *Decoder) Offset() uint {
 	dataDecoder := d.dataDecoder()
 	// This intentionally does not use resolveCtrlData: Offset must return the

--- a/internal/decoder/reflection_test.go
+++ b/internal/decoder/reflection_test.go
@@ -744,5 +744,5 @@ func TestOversizedPointerReturnsError(t *testing.T) {
 }
 
 func testFile(file string) string {
-	return filepath.Join("..", "..", "test-data", "test-data", file)
+	return filepath.Join("..", "..", "testdata", "test-data", file)
 }

--- a/internal/decoder/verifier.go
+++ b/internal/decoder/verifier.go
@@ -7,6 +7,17 @@ import (
 	"github.com/oschwald/maxminddb-golang/v2/internal/mmdberrors"
 )
 
+// VerifyMetadata validates the complete metadata map under one decoding budget.
+// Pointer targets may follow the map and are not search-tree data records.
+func VerifyMetadata(buffer []byte) error {
+	d := NewWithoutStringCache(buffer)
+	var metadata any
+	if err := d.DecodeWithBudget(0, &metadata); err != nil {
+		return err
+	}
+	return validateUTF8(metadata)
+}
+
 // VerifyDataSection verifies the data section against the provided
 // offsets from the tree.
 func (d *ReflectionDecoder) VerifyDataSection(offsets map[uint]bool) error {

--- a/maxminddb-gen/generate.go
+++ b/maxminddb-gen/generate.go
@@ -1436,11 +1436,15 @@ func (g *generator) emitStruct(out *strings.Builder, info structInfo) {
 		info.named.Obj().Name(),
 	)
 	out.WriteString("\tnext := entries.First()\n")
+	seenFields := "seenFields"
+	for suffix := 1; g.pkg.Types.Scope().Lookup(seenFields) != nil; suffix++ {
+		seenFields = "seenFields" + strconv.Itoa(suffix)
+	}
 	if len(info.fields) != 0 {
 		if len(info.fields) <= 64 {
-			out.WriteString("\tvar seenFields uint64\n")
+			fmt.Fprintf(out, "\tvar %s uint64\n", seenFields)
 		} else {
-			fmt.Fprintf(out, "\tvar seenFields [%d]uint64\n", (len(info.fields)+63)/64)
+			fmt.Fprintf(out, "\tvar %s [%d]uint64\n", seenFields, (len(info.fields)+63)/64)
 		}
 	}
 	out.WriteString("\tfor range entries.Len() {\n")
@@ -1453,9 +1457,9 @@ func (g *generator) emitStruct(out *strings.Builder, info structInfo) {
 	out.WriteString("\t\tswitch string(key) {\n")
 	for fieldIndex, field := range info.fields {
 		fmt.Fprintf(out, "\t\tcase %s:\n", strconv.Quote(field.name))
-		seenField := "seenFields"
+		seenField := seenFields
 		if len(info.fields) > 64 {
-			seenField = fmt.Sprintf("seenFields[%d]", fieldIndex/64)
+			seenField = fmt.Sprintf("%s[%d]", seenFields, fieldIndex/64)
 		}
 		fieldBit := uint64(1) << (fieldIndex % 64)
 		fmt.Fprintf(out, "\t\t\tif %s&%d != 0 {\n", seenField, fieldBit)

--- a/maxminddb-gen/generate_test.go
+++ b/maxminddb-gen/generate_test.go
@@ -1113,8 +1113,8 @@ func TestMaxSizeRejectsBeforeMutation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			keep := "keep"
 			newRecord := func() Record {
+				keep := "keep"
 				return Record{
 					Text:        "keep",
 					Bytes:       []byte{9},

--- a/maxminddb-gen/generate_test.go
+++ b/maxminddb-gen/generate_test.go
@@ -2184,6 +2184,31 @@ type Record struct {
 	require.Equal(t, generated, readTestFile(t, "model_maxminddb.go"))
 }
 
+func TestGeneratedSeenFieldsDoesNotShadowTypes(t *testing.T) {
+	for _, fieldCount := range []int{2, 65} {
+		t.Run(fmt.Sprintf("%d fields", fieldCount), func(t *testing.T) {
+			var model strings.Builder
+			model.WriteString(
+				"package fixture\n\ntype seenFields string\ntype seenFields1 string\n\ntype Record struct {\n",
+			)
+			model.WriteString("Value seenFields\n")
+			for i := 1; i < fieldCount; i++ {
+				fmt.Fprintf(&model, "Value%d seenFields1\n", i)
+			}
+			model.WriteString("}\n")
+			dir := newTestModule(t, model.String())
+
+			t.Chdir(dir)
+			require.NoError(t, run([]string{"model.go"}))
+			generated := readTestFile(t, "model_maxminddb.go")
+			testGeneratedPackage(t)
+
+			require.NoError(t, run([]string{"model.go"}))
+			require.Equal(t, generated, readTestFile(t, "model_maxminddb.go"))
+		})
+	}
+}
+
 func TestRunHonorsOutputOverride(t *testing.T) {
 	dir := newTestModule(t, "package fixture\n\ntype Record struct{}\n")
 	t.Chdir(dir)

--- a/mmdbdata/cursor_offset_test.go
+++ b/mmdbdata/cursor_offset_test.go
@@ -1,0 +1,172 @@
+package mmdbdata
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCursorOffsetReturnsControlByte(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		buffer []byte
+		offset uint
+		value  string
+	}{
+		{name: "zero offset", buffer: []byte{0x41, 'x'}, value: "x"},
+		{name: "nonzero offset", buffer: []byte{0x40, 0x41, 'x'}, offset: 1, value: "x"},
+		{name: "extended size", buffer: append([]byte{0x5d, 0}, strings.Repeat("x", 29)...), value: strings.Repeat("x", 29)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			decoder := NewDecoder(test.buffer, test.offset)
+			cursor := decoder.Cursor()
+			offset, err := cursor.Offset()
+			require.NoError(t, err)
+			require.Equal(t, test.offset, offset)
+			require.Equal(t, offset, decoder.Offset())
+
+			value, _, err := cursor.ReadString()
+			require.NoError(t, err)
+			require.Equal(t, test.value, value)
+			value, err = decoder.ReadString()
+			require.NoError(t, err)
+			require.Equal(t, test.value, value)
+		})
+	}
+}
+
+func TestCursorOffsetResolvesPointerWidths(t *testing.T) {
+	for _, test := range []struct {
+		name    string
+		pointer []byte
+		target  uint
+	}{
+		{name: "one byte", pointer: []byte{0x20, 2}, target: 2},
+		{name: "two bytes", pointer: []byte{0x28, 0, 0}, target: 2048},
+		{name: "three bytes", pointer: []byte{0x30, 0, 0, 0}, target: 526336},
+		{name: "four bytes", pointer: []byte{0x38, 0, 0, 0, 5}, target: 5},
+		{name: "ignored high bits", pointer: []byte{0x3f, 0, 0, 0, 5}, target: 5},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			// An extended string size makes the control byte and payload offsets
+			// distinct even after the pointer has been followed.
+			value := strings.Repeat("x", 29)
+			buffer := make([]byte, test.target+2+uint(len(value)))
+			copy(buffer, test.pointer)
+			buffer[test.target] = 0x5d
+			copy(buffer[test.target+2:], value)
+			decoder := NewDecoder(buffer, 0)
+			cursor := decoder.Cursor()
+			offset, err := cursor.Offset()
+			require.NoError(t, err)
+			require.Equal(t, test.target, offset)
+			require.Equal(t, offset, decoder.Offset())
+
+			decoded, next, err := cursor.ReadString()
+			require.NoError(t, err)
+			require.Equal(t, value, decoded)
+			require.NoError(t, decoder.Advance(next))
+			decoded, err = NewDecoder(buffer, offset).ReadString()
+			require.NoError(t, err)
+			require.Equal(t, value, decoded)
+		})
+	}
+}
+
+func TestCursorOffsetIdentifiesRepeatedValues(t *testing.T) {
+	// Two pointers and their direct target must use the same cache key.
+	cursor := NewDecoder([]byte{0x41, 'x', 0x20, 0, 0x20, 0}, 0).Cursor()
+	for range 3 {
+		offset, err := cursor.Offset()
+		require.NoError(t, err)
+		require.Zero(t, offset)
+		value, next, err := cursor.ReadString()
+		require.NoError(t, err)
+		require.Equal(t, "x", value)
+		cursor = next
+	}
+}
+
+func TestCursorOffsetResolutionErrors(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		buffer    []byte
+		offset    uint
+		wantError string
+	}{
+		{name: "empty input"},
+		{name: "past input", buffer: []byte{0x40}, offset: 1},
+		{name: "maximal offset", buffer: []byte{0x40}, offset: ^uint(0)},
+		{name: "truncated extended kind", buffer: []byte{0x40, 0}, offset: 1},
+		{name: "truncated size", buffer: []byte{0x40, 0x5d}, offset: 1},
+		{name: "truncated pointer", buffer: []byte{0x40, 0x20}, offset: 1},
+		{name: "truncated wide pointer", buffer: []byte{0x40, 0x38, 0, 0, 0}, offset: 1},
+		{name: "target past input", buffer: []byte{0x40, 0x20, 3}, offset: 1},
+		{name: "maximal pointer target", buffer: []byte{0x40, 0x38, 0xff, 0xff, 0xff, 0xff}, offset: 1},
+		{name: "truncated target kind", buffer: []byte{0x40, 0x20, 3, 0}, offset: 1},
+		{name: "truncated target size", buffer: []byte{0x40, 0x20, 3, 0x5d}, offset: 1},
+		{name: "pointer chain", buffer: []byte{0x40, 0x20, 3, 0x20, 5, 0x40}, offset: 1, wantError: "pointer-to-pointer chain detected"},
+		{name: "self pointer", buffer: []byte{0x40, 0x20, 1}, offset: 1, wantError: "pointer-to-pointer chain detected"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			decoder := NewDecoder(test.buffer, test.offset)
+			cursor := decoder.Cursor()
+			offset, err := cursor.Offset()
+			require.Zero(t, offset)
+			var invalid InvalidDatabaseError
+			require.ErrorAs(t, err, &invalid)
+			require.ErrorContains(t, err, fmt.Sprintf("at offset %d:", test.offset))
+			wantError := test.wantError
+			if wantError == "" {
+				wantError = "unexpected end of database"
+			}
+			require.ErrorContains(t, err, wantError)
+
+			// Resolution errors follow Kind's error contract and do not change
+			// the legacy method's original-offset fallback.
+			_, kindErr := cursor.Kind()
+			require.Error(t, kindErr)
+			require.EqualError(t, err, kindErr.Error())
+			require.Equal(t, test.offset, decoder.Offset())
+		})
+	}
+}
+
+func TestCursorOffsetRejectsZeroCursor(t *testing.T) {
+	offset, err := (Cursor{}).Offset()
+	require.Zero(t, offset)
+	require.EqualError(t, err, "invalid zero cursor")
+}
+
+func TestCursorOffsetDoesNotValidatePayload(t *testing.T) {
+	cursor := NewDecoder([]byte{0x20, 2, 0x44}, 0).Cursor()
+	offset, err := cursor.Offset()
+	require.NoError(t, err)
+	require.Equal(t, uint(2), offset)
+	_, _, err = cursor.ReadString()
+	require.Error(t, err)
+}
+
+func BenchmarkCursorOffset(b *testing.B) {
+	for _, test := range []struct {
+		name   string
+		buffer []byte
+	}{
+		{name: "direct", buffer: []byte{0x41, 'x'}},
+		{name: "pointer", buffer: []byte{0x20, 2, 0x41, 'x'}},
+		{name: "wide pointer", buffer: []byte{0x38, 0, 0, 0, 5, 0x41, 'x'}},
+	} {
+		b.Run(test.name, func(b *testing.B) {
+			cursor := NewDecoder(test.buffer, 0).Cursor()
+			b.ReportAllocs()
+			for b.Loop() {
+				_, err := cursor.Offset()
+				if err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/mmdbdata/type.go
+++ b/mmdbdata/type.go
@@ -63,6 +63,7 @@ type Decoder = decoder.Decoder
 //
 // Cursor provides these operations:
 //
+//	func (Cursor) Offset() (uint, error)
 //	func (Cursor) Kind() (Kind, error)
 //	func (Cursor) Skip() (Cursor, error)
 //	func (Cursor) ReadBool() (bool, Cursor, error)
@@ -84,6 +85,12 @@ type Decoder = decoder.Decoder
 //	func (Cursor) ReadMapKey() ([]byte, Cursor, error)
 //	func (Cursor) Unmarshal(Unmarshaler) (Cursor, error)
 //	func (Cursor) UnmarshalCursor(CursorUnmarshaler) (Cursor, error)
+//
+// Offset returns the current value's control-byte offset without consuming it.
+// It resolves one pointer so callers can cache values by offset within one
+// database. It returns an error for a zero cursor, malformed control data, or a
+// pointer that cannot be resolved, including a pointer-to-pointer chain.
+// Successful resolution does not validate the value's payload.
 //
 // Kind resolves a valid pointer and reports its target kind without consuming
 // the cursor.

--- a/reader_test.go
+++ b/reader_test.go
@@ -1637,11 +1637,11 @@ func randomIPv4Address(r *rand.Rand, ip []byte) netip.Addr {
 }
 
 func testFile(file string) string {
-	return filepath.Join("test-data", "test-data", file)
+	return filepath.Join("testdata", "test-data", file)
 }
 
 func badDataFile(file string) string {
-	return filepath.Join("test-data", "bad-data", file)
+	return filepath.Join("testdata", "bad-data", file)
 }
 
 // Test custom unmarshaling through Reader.Lookup.

--- a/verifier.go
+++ b/verifier.go
@@ -130,8 +130,7 @@ func (v *verifier) verifyMetadata() error {
 			return mmdberrors.NewInvalidDatabaseError("metadata marker not found")
 		}
 		metadataOffset := markerOffset + len(metadataStartMarker)
-		rawDecoder := decoder.NewWithoutStringCache(v.reader.buffer[metadataOffset:])
-		if err := rawDecoder.VerifyDataSection(map[uint]bool{0: true}); err != nil {
+		if err := decoder.VerifyMetadata(v.reader.buffer[metadataOffset:]); err != nil {
 			return err
 		}
 	}

--- a/verifier_test.go
+++ b/verifier_test.go
@@ -168,6 +168,46 @@ func TestVerifyRejectsInvalidPointerInUnknownMetadataField(t *testing.T) {
 	require.Error(t, reader.Verify())
 }
 
+func TestVerifyMetadataPointersAfterRoot(t *testing.T) {
+	tests := []struct {
+		name    string
+		value   []byte
+		wantErr string
+	}{
+		{name: "valid string", value: []byte{0x42, 'o', 'k'}},
+		{name: "invalid string", value: []byte{0x41, 0xff}, wantErr: "invalid UTF-8"},
+		{name: "invalid map key", value: []byte{0xe1, 0x41, 0xff, 0xe0}, wantErr: "invalid UTF-8"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := os.ReadFile(testFile("MaxMind-DB-test-ipv4-24.mmdb"))
+			require.NoError(t, err)
+			markerOffset := bytes.LastIndex(data, metadataStartMarker)
+			require.NotEqual(t, -1, markerOffset)
+			metadataOffset := markerOffset + len(metadataStartMarker)
+			require.Equal(t, byte(0xe9), data[metadataOffset])
+			data[metadataOffset] = 0xea
+			data = append(data, 0x47)
+			data = append(data, "unknown"...)
+			// Point to a value stored immediately after the metadata map.
+			target := len(data) - metadataOffset + 2
+			require.Less(t, target, 2048)
+			data = append(data, 0x20|byte(target>>8), byte(target))
+			data = append(data, tt.value...)
+
+			reader, err := OpenBytes(data)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, reader.Close()) })
+			err = reader.Verify()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestVerifyOnGoodDatabases(t *testing.T) {
 	databases := []string{
 		"GeoIP2-Anonymous-IP-Test.mmdb",
@@ -186,6 +226,7 @@ func TestVerifyOnGoodDatabases(t *testing.T) {
 		"MaxMind-DB-test-ipv6-24.mmdb",
 		"MaxMind-DB-test-ipv6-28.mmdb",
 		"MaxMind-DB-test-ipv6-32.mmdb",
+		"MaxMind-DB-test-metadata-pointers.mmdb",
 		"MaxMind-DB-test-mixed-24.mmdb",
 		"MaxMind-DB-test-mixed-28.mmdb",
 		"MaxMind-DB-test-mixed-32.mmdb",


### PR DESCRIPTION
Add `mmdbdata.Cursor.Offset() (uint, error)` for caching values by their resolved control-byte offsets. Zero cursors, unreadable source or target headers, unresolved pointers, and pointer-to-pointer chains return contextual errors. Resolution preserves the cursor and does not validate the target payload. Legacy `Decoder.Offset()` retains its original fallback behavior and implementation.

Fix three verifier and generator issues in separate commits:

- Allow metadata pointers to target values after the root map. Verify the complete metadata graph, including unknown fields, under one decoding budget with UTF-8 validation, without applying search-tree record accounting.
- Choose a generated duplicate-key tracking variable that does not shadow package types such as `seenFields` or its numbered alternatives. Cover both small and 65-field structs and deterministic regeneration.
- Give the maxsize mutation test independent actual and expected pointees so an unexpected write cannot alter both sides of the assertion.

A separate commit moves the fixture submodule from `test-data` to `testdata`, updating fixture, fuzz-seed, example, and tooling paths. Recursive Go tooling now skips the fixture submodule. The new offset API has a 2.6.0 changelog entry.

Validation:

- Full `go test -race ./...` on Go 1.26.5 and full Go 1.25.12/linux/386 tests pass. Root and decoder tests were repeated on both configurations after the final verifier adjustment.
- Repository lint, formatting, and normal pre-commit hooks pass.
- Regression tests reproduce both production failures before the fixes. Metadata tests retain coverage for malformed pointers, invalid UTF-8, and container/payload amplification through unknown fields.
- Regenerated GeoIP2 decoders separately against pre-fix `faa4a25` and the final branch. Generated source is identical, and both builds agree on all 1,024 sampled real City records. The complete City benchmark machine-code sections are also byte-identical.
- Twelve samples per variant show no significant change in any of six real City workloads: generated/reflection, fresh/reused lookup, and reused decode-only. A repeated-baseline control also shows no significant changes. Allocated bytes and allocation counts are unchanged.
- Metadata verification is 1.46% faster on the real City database and statistically unchanged on the metadata-pointer fixture, with unchanged allocations.
- Twelve-sample legacy offset comparisons against main `67d6bfb` show no significant regression across all pointer widths.

City measurements use the unchanged benchmark source and the 2026-09-04 GeoLite2 City database (SHA-256 `892f711a139a5c76dd2b7908f087148c729df287a504336daa2ccc7e2292ebbd`). Samples run 1,000,000 City operations or 100,000 metadata verifications, pinned to CPU 3 with one Go execution thread on an Intel Core Ultra 7 265K. The City baseline, candidate, and control orders are balanced across all six permutations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `Cursor.Offset()` to retrieve resolved control-byte offsets without consuming values, supporting stable offset-based caching.
  - Reports errors for invalid cursors, malformed data, and unresolved pointer chains.

- **Bug Fixes**
  - Improved metadata verification for values located after the metadata map while preserving decoding and UTF-8 validation.
  - Prevented generated code from conflicting with application type names.

- **Documentation**
  - Clarified offset fallback behavior and documented `Cursor.Offset()` usage and error conditions.

- **Tests**
  - Expanded coverage for offsets, pointer resolution, metadata validation, caching, and invalid data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->