### PR TITLE
Require Go 1.26 and test Go 1.27

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build
     strategy:
       matrix:
-        go-version: [1.26, 1.25]
+        go-version: ["1.27", "1.26"]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -35,13 +35,13 @@ jobs:
         run: go test -race -v ./...
 
   test-386:
-    name: Test (Go 1.25, linux/386)
+    name: Test (Go 1.26, linux/386)
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go 1.25
+      - name: Set up Go 1.26
         uses: actions/setup-go@v7
         with:
-          go-version: "1.25"
+          go-version: "1.26"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v7

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.25"
+  go: "1.26"
   tests: true
   allow-parallel-runners: true
 linters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## 2.7.0
+
+- Go 1.26 or later is now required. CI now tests Go 1.26 and 1.27.
+
 ## 2.6.0 - 2026-09-07
 
 - Fixed a denial-of-service issue where a crafted database could use repeated

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Download from
 
 ## Requirements
 
-- Go 1.25 or later
+- Go 1.26 or later
 - MaxMind DB file in .mmdb format
 
 ## Contributing

--- a/example_uint_test.go
+++ b/example_uint_test.go
@@ -15,8 +15,7 @@ func TestCustomCityNormalizesKindMismatch(t *testing.T) {
 	_, err := city.UnmarshalMaxMindDBCursor(
 		mmdbdata.NewDecoder([]byte{0x40}, 0).Cursor(),
 	)
-	var typeError maxminddb.UnmarshalTypeError
-	if !errors.As(err, &typeError) {
+	if _, ok := errors.AsType[maxminddb.UnmarshalTypeError](err); !ok {
 		t.Fatalf("expected UnmarshalTypeError, got %v", err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/oschwald/maxminddb-golang/v2
 
-go 1.25.0
+go 1.26.0
 
 tool github.com/oschwald/maxminddb-golang/v2/maxminddb-gen
 

--- a/internal/decoder/reflection.go
+++ b/internal/decoder/reflection.go
@@ -399,8 +399,7 @@ func (d *ReflectionDecoder) nextValueOffsetBudgetedSlow(
 
 func wrapRootDecodeError(err error, offset uint) error {
 	// Check if error already has context (including path), if so just add offset if missing
-	var contextErr mmdberrors.ContextualError
-	if errors.As(err, &contextErr) {
+	if contextErr, ok := errors.AsType[mmdberrors.ContextualError](err); ok {
 		if contextErr.Offset != 0 || offset == 0 {
 			return err
 		}
@@ -600,8 +599,7 @@ func wrapErrorWithPath(err error, prepend func(*mmdberrors.PathBuilder)) error {
 		return nil
 	}
 
-	var contextErr mmdberrors.ContextualError
-	if errors.As(err, &contextErr) {
+	if contextErr, ok := errors.AsType[mmdberrors.ContextualError](err); ok {
 		pathBuilder := mmdberrors.NewPathBuilder()
 		if contextErr.Path != "" && contextErr.Path != "/" {
 			pathBuilder.ParseAndExtend(contextErr.Path)
@@ -1917,8 +1915,7 @@ func (d *ReflectionDecoder) decodeValueMaxSize(
 		}
 		value, next, err := cursor.ReadStringMaxSize(maximum)
 		if err != nil {
-			var mismatch UnexpectedKindError
-			if errors.As(err, &mismatch) {
+			if _, ok := errors.AsType[UnexpectedKindError](err); ok {
 				return d.decodeValueSkipUnmarshaler(offset, result, depth)
 			}
 			return 0, err

--- a/maxminddb-gen/generate_test.go
+++ b/maxminddb-gen/generate_test.go
@@ -2771,7 +2771,7 @@ func newTestModule(t *testing.T, model string) string {
 	require.NoError(t, err)
 	module := strings.ReplaceAll(`module example.com/generatortest
 
-go 1.25.0
+go 1.26.0
 
 require github.com/oschwald/maxminddb-golang/v2 v2.5.0
 

--- a/maxminddb-gen/testdata/basic/go.mod
+++ b/maxminddb-gen/testdata/basic/go.mod
@@ -1,6 +1,6 @@
 module github.com/oschwald/maxminddb-golang/v2/maxminddb-gen/testdata/basic
 
-go 1.25.0
+go 1.26.0
 
 require github.com/oschwald/maxminddb-golang/v2 v2.5.0
 


### PR DESCRIPTION
Require Go 1.26 or later and test Go 1.26 and 1.27 on Linux, macOS, and Windows. Keep Linux/386 coverage on the minimum supported version.

Update the module declarations, generator fixtures, README, and golangci-lint target; explicitly set up Go from go.mod in the lint workflow. Replace four errors.As calls with errors.AsType as required by the modernize linter at the new Go version. Add the requirement change to the 2.7.0 changelog.

Validation:
- go test -race ./... with Go 1.26.4 and Go 1.27.1
- CGO_ENABLED=0 GOARCH=386 go test -count=1 ./... with Go 1.26.4
- golangci-lint run --timeout=5m and golangci-lint config verify
- go mod tidy -diff, workflow YAML parsing, and git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Go 1.26 or later is now required to build and use the project.
  * Support is validated against Go 1.26 and Go 1.27.

* **Documentation**
  * Updated the README and changelog to reflect the new minimum Go version and supported versions.

* **Maintenance**
  * Updated development and testing workflows to consistently use the current Go versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->